### PR TITLE
Fix Frontend Tests

### DIFF
--- a/frontend_service/app/components/payments/PayBillCard.test.tsx
+++ b/frontend_service/app/components/payments/PayBillCard.test.tsx
@@ -17,6 +17,10 @@ const mockLoginContext = {
   userData: mockUserData,
   setUserData: vi.fn(),
   handleLogout: vi.fn(),
+  userId: 'alice.j@relibank.com',
+  setUserId: vi.fn(),
+  browserUserId: null,
+  setBrowserUserId: vi.fn(),
 };
 
 const renderPayBillCard = () => {
@@ -34,6 +38,11 @@ describe('PayBillCard - Payment Flow', () => {
   });
 
   it('fetches saved payment methods on mount', async () => {
+    // Mock accounts-service to return a stripe customer ID
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ stripe_customer_id: 'cus_test' }),
+    });
     (global.fetch as any).mockResolvedValueOnce({
       ok: true,
       json: async () => ({
@@ -53,6 +62,11 @@ describe('PayBillCard - Payment Flow', () => {
   });
 
   it('validates required fields before submission', async () => {
+    // Mock accounts-service call on mount
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ stripe_customer_id: 'cus_test' }),
+    });
     (global.fetch as any).mockResolvedValueOnce({
       ok: true,
       json: async () => ({ paymentMethods: [] }),
@@ -77,6 +91,11 @@ describe('PayBillCard - Payment Flow', () => {
   });
 
   it('processes bank account payment successfully', async () => {
+    // Mock accounts-service call on mount
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ stripe_customer_id: 'cus_test' }),
+    });
     // Mock payment methods fetch
     (global.fetch as any).mockResolvedValueOnce({
       ok: true,
@@ -114,6 +133,11 @@ describe('PayBillCard - Payment Flow', () => {
   });
 
   it('displays saved payment methods in dropdown', async () => {
+    // Mock accounts-service to return a stripe customer ID
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ stripe_customer_id: 'cus_test' }),
+    });
     // Mock payment methods fetch with cards
     (global.fetch as any).mockResolvedValueOnce({
       ok: true,
@@ -136,6 +160,11 @@ describe('PayBillCard - Payment Flow', () => {
   });
 
   it('resets form after successful payment', async () => {
+    // Mock accounts-service call on mount
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ stripe_customer_id: 'cus_test' }),
+    });
     // Mock payment methods fetch
     (global.fetch as any).mockResolvedValueOnce({
       ok: true,
@@ -175,6 +204,11 @@ describe('PayBillCard - Payment Flow', () => {
   });
 
   it('shows loading state during payment processing', async () => {
+    // Mock accounts-service call on mount
+    (global.fetch as any).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ stripe_customer_id: 'cus_test' }),
+    });
     // Mock payment methods fetch
     (global.fetch as any).mockResolvedValueOnce({
       ok: true,

--- a/frontend_service/app/routes/login.test.tsx
+++ b/frontend_service/app/routes/login.test.tsx
@@ -28,6 +28,10 @@ const mockLoginContext = {
   handleLogout: vi.fn(),
   userData: null,
   setUserData: vi.fn(),
+  userId: null,
+  setUserId: vi.fn(),
+  browserUserId: null,
+  setBrowserUserId: vi.fn(),
 };
 
 const renderLogin = () => {

--- a/frontend_service/package-lock.json
+++ b/frontend_service/package-lock.json
@@ -9,7 +9,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "^7.3.1",
         "@mui/material": "^7.3.1",
-        "@newrelic/browser-agent": "^1.296.0",
+        "@newrelic/browser-agent": "^1.312.1",
         "@react-router/node": "^7.7.1",
         "@react-router/serve": "^7.7.1",
         "isbot": "^5.1.27",
@@ -1664,18 +1664,64 @@
       }
     },
     "node_modules/@newrelic/browser-agent": {
-      "version": "1.296.0",
-      "resolved": "https://registry.npmjs.org/@newrelic/browser-agent/-/browser-agent-1.296.0.tgz",
-      "integrity": "sha512-3/rGPp0L21G4CfDafhgvTdxYk5M+BC1BxV5YjLvXxx69QtvvoB/izos5NQqyFGsdkgVhLzmouESq3zGptUgbag==",
+      "version": "1.313.1",
+      "resolved": "https://registry.npmjs.org/@newrelic/browser-agent/-/browser-agent-1.313.1.tgz",
+      "integrity": "sha512-WS90b7XKSLrOjrVywP3xxUKOwjzg4wLDDvYVvsEpEy1bDI7FE62Kqz2QWGVggw8o4x/rYTF0AXk7d69UGSOyvA==",
       "license": "Apache-2.0",
       "dependencies": {
+        "@newrelic/rrweb": "1.1.0",
         "fflate": "0.8.2",
-        "rrweb": "^2.0.0-alpha.18",
         "web-vitals": "4.2.4"
       },
       "engines": {
         "node": ">=12.17.0 < 13.0.0 || >=13.7.0"
       }
+    },
+    "node_modules/@newrelic/rrdom": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/rrdom/-/rrdom-1.1.0.tgz",
+      "integrity": "sha512-NQK9bJMdw2pGitekR44rgvILpzBpdZQrn98+5RGGh7V7+z+k+zwpdFmptHIvcY6Bxej//k7IupFyza1vidg5bw==",
+      "license": "MIT",
+      "dependencies": {
+        "@newrelic/rrweb-snapshot": "^1.1.0"
+      }
+    },
+    "node_modules/@newrelic/rrweb": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/rrweb/-/rrweb-1.1.0.tgz",
+      "integrity": "sha512-3QmDsDf0ZTi0upNiSjTKSqmPF7Y/WIm9NvfEYQnqejfowIuV4tgDBt0FePSpgkT0usFGDigXpAGE+VZQi5OqEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@newrelic/rrdom": "^1.1.0",
+        "@newrelic/rrweb-snapshot": "^1.1.0",
+        "@newrelic/rrweb-types": "^1.1.0",
+        "@newrelic/rrweb-utils": "^1.1.0",
+        "@types/css-font-loading-module": "0.0.7",
+        "@xstate/fsm": "^1.4.0",
+        "base64-arraybuffer": "^1.0.1",
+        "mitt": "^3.0.0"
+      }
+    },
+    "node_modules/@newrelic/rrweb-snapshot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/rrweb-snapshot/-/rrweb-snapshot-1.1.0.tgz",
+      "integrity": "sha512-wvtz4RbTjRhLYVq/XPX9rAL6ifeCt6o3pnwUiR3SpUHBSYVGYPJuFQr3tEGh3BWYae3nfzNmOj73tGIc7SbSGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
+      }
+    },
+    "node_modules/@newrelic/rrweb-types": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/rrweb-types/-/rrweb-types-1.1.0.tgz",
+      "integrity": "sha512-R+QhmPYuZdzsYmA4A8huNm+nqWKipbySMO5tAJD/gvfi820k4CJMUYxtc7k3YVuO/DeAjmJwQ8R1KzZNnorZwA==",
+      "license": "MIT"
+    },
+    "node_modules/@newrelic/rrweb-utils": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@newrelic/rrweb-utils/-/rrweb-utils-1.1.0.tgz",
+      "integrity": "sha512-vMuhV4+8dZxXkaAQM9g0ULa0bUAkeJDMCHds8j82VChdxETJWGXBIlaj/tuQXWGp2kmY6hwhnALy7Gc+xVlHlA==",
+      "license": "MIT"
     },
     "node_modules/@npmcli/git": {
       "version": "4.1.0",
@@ -2207,18 +2253,6 @@
       "os": [
         "win32"
       ]
-    },
-    "node_modules/@rrweb/types": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@rrweb/types/-/types-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-iMH3amHthJZ9x3gGmBPmdfim7wLGygC2GciIkw2A6SO8giSn8PHYtRT8OKNH4V+k3SZ6RSnYHcTQxBA7pSWZ3Q==",
-      "license": "MIT"
-    },
-    "node_modules/@rrweb/utils": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/@rrweb/utils/-/utils-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-qV8azQYo9RuwW4NGRtOiQfTBdHNL1B0Q//uRLMbCSjbaKqJYd88Js17Bdskj65a0Vgp2dwTLPIZ0gK47dfjfaA==",
-      "license": "MIT"
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
@@ -6081,40 +6115,6 @@
         "@rollup/rollup-win32-ia32-msvc": "4.46.2",
         "@rollup/rollup-win32-x64-msvc": "4.46.2",
         "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/rrdom": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/rrdom/-/rrdom-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-fSFzFFxbqAViITyYVA4Z0o5G6p1nEqEr/N8vdgSKie9Rn0FJxDSNJgjV0yiCIzcDs0QR+hpvgFhpbdZ6JIr5Nw==",
-      "license": "MIT",
-      "dependencies": {
-        "rrweb-snapshot": "^2.0.0-alpha.18"
-      }
-    },
-    "node_modules/rrweb": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/rrweb/-/rrweb-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-1mjZcB+LVoGSx1+i9E2ZdAP90fS3MghYVix2wvGlZvrgRuLCbTCCOZMztFCkKpgp7/EeCdYM4nIHJkKX5J1Nmg==",
-      "license": "MIT",
-      "dependencies": {
-        "@rrweb/types": "^2.0.0-alpha.18",
-        "@rrweb/utils": "^2.0.0-alpha.18",
-        "@types/css-font-loading-module": "0.0.7",
-        "@xstate/fsm": "^1.4.0",
-        "base64-arraybuffer": "^1.0.1",
-        "mitt": "^3.0.0",
-        "rrdom": "^2.0.0-alpha.18",
-        "rrweb-snapshot": "^2.0.0-alpha.18"
-      }
-    },
-    "node_modules/rrweb-snapshot": {
-      "version": "2.0.0-alpha.18",
-      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.18.tgz",
-      "integrity": "sha512-hBHZL/NfgQX6wO1D9mpwqFu1NJPpim+moIcKhFEjVTZVRUfCln+LOugRc4teVTCISYHN8Cw5e2iNTWCSm+SkoA==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss": "^8.4.38"
       }
     },
     "node_modules/safe-buffer": {

--- a/tests/test_mfe_single.py
+++ b/tests/test_mfe_single.py
@@ -1,36 +1,82 @@
+"""
+Single focused test for MFE timing events in New Relic.
+
+Generates traffic and waits 3 minutes for ingestion, then verifies that
+MicroFrontEndTiming events are present in New Relic.
+
+Prerequisites:
+- NEW_RELIC_USER_API_KEY environment variable
+- NEW_RELIC_ACCOUNT_ID environment variable (defaults to 4182956)
+- Frontend service running with microfrontends built
+- Chrome and chromedriver installed
+"""
+
 import os
 import time
+import pytest
+
 from generate_mfe_traffic import generate_mfe_traffic_with_selenium
+from test_microfrontend_telemetry import query_nrql
 
 FRONTEND_URL = os.getenv("RELIBANK_URL", "http://localhost:3000")
 NEW_RELIC_API_KEY = os.getenv("NEW_RELIC_USER_API_KEY")
 NEW_RELIC_ACCOUNT_ID = os.getenv("NEW_RELIC_ACCOUNT_ID", "4182956")
 
-if not NEW_RELIC_API_KEY:
-    print("ERROR: NEW_RELIC_USER_API_KEY environment variable not set")
-    print("Usage: export NEW_RELIC_USER_API_KEY='your-key' && python test_mfe_single.py")
-    exit(1)
+MFE_NAMES = {
+    '550e8400-e29b-41d4-a716-446655440000': 'AdBanner',
+    '650e8400-e29b-41d4-a716-446655440001': 'SpendingChart',
+    '750e8400-e29b-41d4-a716-446655440002': 'SpendingCategories',
+    '850e8400-e29b-41d4-a716-446655440003': 'AccountBalanceTrends',
+}
+MFE_SOURCE_IDS_LIST = list(MFE_NAMES.keys())
+MFE_SOURCE_IDS = ", ".join(f"'{sid}'" for sid in MFE_SOURCE_IDS_LIST)
 
-from test_microfrontend_telemetry import query_nrql
+pytestmark = pytest.mark.skipif(
+    not NEW_RELIC_API_KEY,
+    reason="NEW_RELIC_USER_API_KEY environment variable not set"
+)
 
-print("Generating traffic...")
-generate_mfe_traffic_with_selenium(FRONTEND_URL)
 
-print("\nWaiting 180 seconds (3 minutes) for New Relic ingestion...")
-time.sleep(180)
+def generate_traffic():
+    """Generate MFE traffic and wait for New Relic ingestion."""
+    print("\n" + "=" * 80)
+    print("SETUP: Generating dashboard traffic with Selenium")
+    print("=" * 80)
+    print(f"Frontend URL: {FRONTEND_URL}")
 
-nrql = """
-    SELECT count(*) FROM MicroFrontEndTiming
-    WHERE source.id IN ('550e8400-e29b-41d4-a716-446655440000', '650e8400-e29b-41d4-a716-446655440001', '750e8400-e29b-41d4-a716-446655440002', '850e8400-e29b-41d4-a716-446655440003')
-    SINCE 15 minutes ago
-"""
+    generate_mfe_traffic_with_selenium(FRONTEND_URL)
 
-print(f"\nQuerying New Relic...")
-results = query_nrql(nrql)
-count = results[0]["count"] if results else 0
-print(f"MicroFrontEndTiming events found: {count}")
+    print("\n⏳ Waiting 180 seconds (3 minutes) for New Relic ingestion...")
+    print("=" * 80 + "\n")
+    time.sleep(180)
 
-if count > 0:
-    print("\n✅ SUCCESS! Events are appearing in New Relic!")
-else:
-    print("\n⚠️ No events yet - might need prod/staging environment")
+
+@pytest.mark.slow
+def test_mfe_timing_events_exist():
+    """Verify MicroFrontEndTiming events appear in New Relic after traffic generation."""
+    generate_traffic()
+
+    nrql = f"""
+        SELECT count(*) FROM MicroFrontEndTiming
+        WHERE source.id IN ({MFE_SOURCE_IDS})
+        FACET source.id
+        SINCE 15 minutes ago
+    """
+
+    print(f"Querying NRQL: {nrql}")
+    results = query_nrql(nrql)
+
+    counts_by_id = {r["source.id"]: r["count"] for r in results if "source.id" in r}
+    print("MicroFrontEndTiming event counts by source.id:")
+    for sid, count in counts_by_id.items():
+        print(f"  {sid}: {count}  ({MFE_NAMES.get(sid, 'unknown')})")
+
+    missing = [sid for sid in MFE_SOURCE_IDS_LIST if counts_by_id.get(sid, 0) == 0]
+
+    assert len(missing) == 0, (
+        f"Expected all MFEs to report MicroFrontEndTiming events, "
+        f"but {len(missing)} did not: {missing}. "
+        "Ensure browser agent has api.register.enabled = true and MFEs are calling .register()"
+    )
+
+    print(f"✅ All {len(MFE_SOURCE_IDS_LIST)} MFEs reported MicroFrontEndTiming events")

--- a/tests/test_microfrontend_telemetry.py
+++ b/tests/test_microfrontend_telemetry.py
@@ -127,26 +127,32 @@ def test_microfrontend_timing_events_exist():
     # Generate traffic first
     generate_dashboard_traffic()
 
-    # Query for MicroFrontEndTiming events from any of our 4 MFEs
-    # Note: Use source.id which contains our configured UUIDs, not entityGuid
+    # Query for MicroFrontEndTiming events from each MFE via FACET to avoid
+    # false positives where only one MFE reports traffic
     source_ids = "', '".join(MFE_CONFIGS.values())
     nrql = f"""
         SELECT count(*) FROM MicroFrontEndTiming
         WHERE source.id IN ('{source_ids}')
+        FACET source.id
         SINCE 10 minutes ago
     """
 
     print(f"Querying NRQL: {nrql}")
     results = query_nrql(nrql)
-    count = results[0]["count"] if results else 0
 
-    print(f"\n📊 MicroFrontEndTiming event count: {count}")
+    counts_by_id = {r["source.id"]: r["count"] for r in results if "source.id" in r}
+    mfe_names = {v: k for k, v in MFE_CONFIGS.items()}
+    print("\n📊 MicroFrontEndTiming event counts by source.id:")
+    for sid, count in counts_by_id.items():
+        print(f"  {sid}: {count}  ({mfe_names.get(sid, 'unknown')})")
 
-    assert count > 0, \
-        f"Expected MicroFrontEndTiming events for microfrontends, found {count}. " \
+    missing = [sid for sid in MFE_CONFIGS.values() if counts_by_id.get(sid, 0) == 0]
+
+    assert len(missing) == 0, \
+        f"Expected all MFEs to report MicroFrontEndTiming events, but {len(missing)} did not: {missing}. " \
         "Ensure browser agent has api.register.enabled = true and MFEs are calling .register()"
 
-    print(f"✅ Found {count} MicroFrontEndTiming event(s)")
+    print(f"✅ All {len(MFE_CONFIGS)} MFEs reported MicroFrontEndTiming events")
 
 
 @pytest.mark.slow

--- a/tests/test_with_interactions.py
+++ b/tests/test_with_interactions.py
@@ -1,54 +1,108 @@
+"""
+Test MFE timing events with browser interactions.
+
+Generates traffic using Selenium with MFE interactions (button clicks, navigation)
+and verifies that MicroFrontEndTiming events are captured with valid timing fields.
+
+Prerequisites:
+- NEW_RELIC_USER_API_KEY environment variable
+- NEW_RELIC_ACCOUNT_ID environment variable (defaults to 4182956)
+- Frontend service running with microfrontends built
+- Chrome and chromedriver installed
+"""
+
 import os
 import time
+import pytest
+
 from generate_mfe_traffic import generate_mfe_traffic_with_selenium
 from test_microfrontend_telemetry import query_nrql
 
-# Get from environment variables
+FRONTEND_URL = os.getenv("RELIBANK_URL", "http://localhost:3000")
 NEW_RELIC_API_KEY = os.getenv("NEW_RELIC_USER_API_KEY")
 NEW_RELIC_ACCOUNT_ID = os.getenv("NEW_RELIC_ACCOUNT_ID", "4182956")
 
-if not NEW_RELIC_API_KEY:
-    print("ERROR: NEW_RELIC_USER_API_KEY environment variable not set")
-    print("Usage: export NEW_RELIC_USER_API_KEY='your-key' && python test_with_interactions.py")
-    exit(1)
+MFE_NAMES = {
+    '550e8400-e29b-41d4-a716-446655440000': 'AdBanner',
+    '650e8400-e29b-41d4-a716-446655440001': 'SpendingChart',
+    '750e8400-e29b-41d4-a716-446655440002': 'SpendingCategories',
+    '850e8400-e29b-41d4-a716-446655440003': 'AccountBalanceTrends',
+}
+MFE_SOURCE_IDS_LIST = list(MFE_NAMES.keys())
+MFE_SOURCE_IDS = ", ".join(f"'{sid}'" for sid in MFE_SOURCE_IDS_LIST)
 
-print("=" * 80)
-print("Testing with MFE Interactions (matching goblin-swarm)")
-print("=" * 80)
+pytestmark = pytest.mark.skipif(
+    not NEW_RELIC_API_KEY,
+    reason="NEW_RELIC_USER_API_KEY environment variable not set"
+)
 
-print("\n1. Generating traffic with MFE interactions...")
-generate_mfe_traffic_with_selenium("http://localhost:3000")
 
-print("\n2. Waiting 90 seconds for New Relic ingestion...")
-time.sleep(90)
+def generate_traffic():
+    """Generate MFE traffic with interactions and wait for New Relic ingestion."""
+    print("\n" + "=" * 80)
+    print("SETUP: Generating dashboard traffic with MFE interactions")
+    print("=" * 80)
+    print(f"Frontend URL: {FRONTEND_URL}")
 
-print("\n3. Querying for MicroFrontEndTiming events...")
-nrql = """
-    SELECT count(*) FROM MicroFrontEndTiming
-    WHERE source.id IN ('550e8400-e29b-41d4-a716-446655440000', '650e8400-e29b-41d4-a716-446655440001', '750e8400-e29b-41d4-a716-446655440002', '850e8400-e29b-41d4-a716-446655440003')
-    SINCE 15 minutes ago
-"""
+    generate_mfe_traffic_with_selenium(FRONTEND_URL)
 
-results = query_nrql(nrql)
-count = results[0]["count"] if results else 0
-print(f"\n📊 MicroFrontEndTiming events found: {count}")
+    print("\n⏳ Waiting 90 seconds for New Relic ingestion...")
+    print("=" * 80 + "\n")
+    time.sleep(90)
 
-if count > 0:
-    print("\n✅ SUCCESS! Events are appearing with MFE interactions!")
-    print("\nQuerying for details...")
-    detail_nrql = """
+
+@pytest.mark.slow
+def test_mfe_timing_events_exist():
+    """Verify MicroFrontEndTiming events appear in New Relic after interaction traffic."""
+    generate_traffic()
+
+    nrql = f"""
+        SELECT count(*) FROM MicroFrontEndTiming
+        WHERE source.id IN ({MFE_SOURCE_IDS})
+        FACET source.id
+        SINCE 15 minutes ago
+    """
+
+    print(f"Querying NRQL: {nrql}")
+    results = query_nrql(nrql)
+
+    counts_by_id = {r["source.id"]: r["count"] for r in results if "source.id" in r}
+    print("MicroFrontEndTiming event counts by source.id:")
+    for sid, count in counts_by_id.items():
+        print(f"  {sid}: {count}  ({MFE_NAMES.get(sid, 'unknown')})")
+
+    missing = [sid for sid in MFE_SOURCE_IDS_LIST if counts_by_id.get(sid, 0) == 0]
+
+    assert len(missing) == 0, (
+        f"Expected all MFEs to report MicroFrontEndTiming events after interaction traffic, "
+        f"but {len(missing)} did not: {missing}. "
+        "Ensure browser agent has api.register.enabled = true and MFEs are calling .register()"
+    )
+
+    print(f"✅ All {len(MFE_SOURCE_IDS_LIST)} MFEs reported MicroFrontEndTiming events")
+
+
+@pytest.mark.slow
+def test_mfe_timing_event_details():
+    """Verify MicroFrontEndTiming events contain valid timing fields."""
+    generate_traffic()
+
+    nrql = f"""
         SELECT timeToLoad, timeToRegister, timeAlive, source.id, entity.name
         FROM MicroFrontEndTiming
-        WHERE source.id IN ('550e8400-e29b-41d4-a716-446655440000', '650e8400-e29b-41d4-a716-446655440001', '750e8400-e29b-41d4-a716-446655440002', '850e8400-e29b-41d4-a716-446655440003')
+        WHERE source.id IN ({MFE_SOURCE_IDS})
         SINCE 15 minutes ago LIMIT 10
     """
-    events = query_nrql(detail_nrql)
-    for event in events:
+
+    print(f"Querying NRQL: {nrql}")
+    results = query_nrql(nrql)
+
+    assert len(results) > 0, (
+        "No MicroFrontEndTiming events found. "
+        "Check that dashboard is accessible and MFEs are registering."
+    )
+
+    for event in results:
         print(f"  - {event.get('entity.name')}: timeToRegister={event.get('timeToRegister')}ms")
-else:
-    print("\n⚠️ No events yet")
-    print("Checking for any MicroFrontEndTiming events at all...")
-    any_nrql = "SELECT count(*) FROM MicroFrontEndTiming SINCE 15 minutes ago"
-    any_results = query_nrql(any_nrql)
-    any_count = any_results[0]["count"] if any_results else 0
-    print(f"Total MicroFrontEndTiming events (all sources): {any_count}")
+
+    print(f"✅ Found {len(results)} MicroFrontEndTiming event(s) with details")


### PR DESCRIPTION
```
fix: update npm lock file
fix: missing set user id functions
fix: make frontend tests into pytests
```

🚀 Pull Request
========================

🎯 PR Type
----------
-   [ ] **Feature:** Adds new functionality or user-facing change.
-   [x] **Bug Fix:** Solves a defect or incorrect behavior.
-   [ ] **Refactor:** Improves code structure/readability without changing external behavior.
-   [ ] **Documentation:** Updates to README, Wiki, or internal docs.
-   [ ] **Chore:** Non-code changes (e.g., CI configuration, dependency bumps).

1\. Issue Tracking & Reference
------------------------------
-   **Ticket Number(s):** N/A
-   **Ticket Link(s):** N/A

2\. Summary of Changes
----------------------
Fixes all failing frontend tests in CI. The GitHub Actions `frontend-tests` job was failing due to an out-of-sync `package-lock.json`, three failing vitest unit tests, and two Python test files crashing pytest collection with `SystemExit`.

-   **Expected Outcome:** All frontend-tests and python-tests CI jobs pass cleanly.

### Detailed Change Log & Justification
-   **Change 1:** Updated `frontend_service/package-lock.json` to sync with `package.json`.
    -   **Justification:** `package.json` required `@newrelic/browser-agent@^1.312.1` but the lock file still referenced `1.296.0`, causing `npm ci` to fail with `EUSAGE`. Running `npm install` resolved the version and added the missing `@newrelic/rrweb*` transitive packages.
-   **Change 2:** Added `setUserId`, `userId`, `browserUserId`, and `setBrowserUserId` to `mockLoginContext` in `app/routes/login.test.tsx`.
    -   **Justification:** `login.tsx` destructures `setUserId` from `LoginContext` and calls it on successful login. The mock was missing this field, causing `setUserId is not a function` at runtime and the `submits login form with credentials` test to fail.
-   **Change 3:** Added `userId` to `mockLoginContext` and prepended an `/accounts-service/users/by-id/` fetch mock to every test in `app/components/payments/PayBillCard.test.tsx`.
    -   **Justification:** `PayBillCard.tsx` guards `fetchPaymentMethods` with `if (!userId) { return; }`. With no `userId` in the mock, the component never called fetch, so the two tests asserting `/bill-pay-service/payment-methods/` was called always failed. The component also calls the accounts-service first to retrieve `stripe_customer_id`, so each test needed that mock prepended.
-   **Change 4:** Converted `tests/test_mfe_single.py` from a standalone script to a proper pytest file.
    -   **Justification:** The file called `exit(1)` at module level when `NEW_RELIC_USER_API_KEY` was missing, causing pytest to crash with `INTERNALERROR> SystemExit: 1` during collection and marking the file as failed even though no tests ran.
-   **Change 5:** Converted `tests/test_with_interactions.py` from a standalone script to a proper pytest file with two test functions.
    -   **Justification:** Same `exit(1)` at module level issue as above. Additionally, the file had a hardcoded `localhost:3000` URL replaced with the `RELIBANK_URL` environment variable, and the implicit `if count > 0` verification block was split into two explicit asserting test functions.

3\. Testing
-----------

### Testing Strategy
-   **Environment Used:** Local and GitHub Actions (CI)
-   **Production Safety Assessment:** All changes are confined to test files and the `package-lock.json`. No application source code was modified.
-   **What areas were NOT tested and why?** The `test_mfe_single.py` and `test_with_interactions.py` tests require `NEW_RELIC_USER_API_KEY` and a live environment to fully execute; they were verified to collect and skip cleanly without the key.

### Coverage Details

| Scenario | Details | Results |
| --- | --- | --- |
| Happy Path | All 37 vitest tests pass locally | ✅ 37 passed |
| Happy Path | `test_mfe_single.py` and `test_with_interactions.py` collect and skip cleanly without API key | ✅ 3 skipped |
| Edge Case 1 | `PayBillCard` tests with `userId` set — accounts-service mock consumed before payment-methods mock | ✅ All 6 PayBillCard tests pass |
| Edge Case 2 | `login.test.tsx` — `setUserId` called after successful auth response | ✅ All 4 login tests pass |

4\. Evidence
------------
-   **Screenshots/Gifs:** N/A
-   **Console/Log Output Snippets:**
```
 Test Files  5 passed (5)
      Tests  37 passed (37)
   Start at  11:23:38
   Duration  7.21s
```
```
test_mfe_single.py::test_mfe_timing_events_exist SKIPPED (NEW_RELIC_...)
test_with_interactions.py::test_mfe_timing_events_exist SKIPPED (NEW_...)
test_with_interactions.py::test_mfe_timing_event_details SKIPPED (NE_...)
3 skipped in 0.07s
```
-   **GitHub Actions:** `frontend-tests` job passed on CI run #126 (all 37 vitest tests green, no `npm ci` errors).
-   **Test Report Links:** N/A

_Testing and evidence are **REQUIRED** before requesting review!_

5\. Review and Merge Checklist
------------------------------
-   [x] All blocking review comments from the latest round are **resolved**.
-   [x] This branch has been rebased against the `main` branch and all **merge conflicts are resolved**.
-   [x] The code includes sufficient comments, particularly in complex or non-obvious areas.
-   [x] The code adheres to project **coding standards** (linting, style guides, best practices).
-   [x] Relevant documentation and runbooks have been updated, if necessary.
-   [x] My changes generate no new warnings or errors.
-   [x] My commits are squashed into a single, descriptive commit.
-   [x] My test results are uploaded as a text file, and new tests were created where required.