### PR TITLE
fix: generate nrdot-mssql.env before kustomize apply

### DIFF
--- a/.github/workflows/build-push-images.yml
+++ b/.github/workflows/build-push-images.yml
@@ -166,6 +166,19 @@ jobs:
             echo "✅ Push successful for ${IMAGE_NAME}"
           done
 
+      - name: Generate nrdot-mssql.env
+        if: (inputs.deploy == true || inputs.deploy == 'true') || inputs.skip_build == true
+        run: |
+          set -a
+          source skaffold.env
+          set +a
+          printf 'MSSQL_NEWRELIC_PASSWORD=%s\nNEW_RELIC_LICENSE_KEY=%s\nNEW_RELIC_OTLP_ENDPOINT=%s\n' \
+            "${MSSQL_NEWRELIC_PASSWORD}" \
+            "${NEW_RELIC_LICENSE_KEY}" \
+            "${NEW_RELIC_OTLP_ENDPOINT:-https://otlp.nr-data.net}" \
+            > k8s/base/infrastructure/newrelic/nrdot-mssql.env
+          echo "✅ nrdot-mssql.env generated"
+
       - name: Deploy to AKS
         if: (inputs.deploy == true || inputs.deploy == 'true') || inputs.skip_build == true
         run: |


### PR DESCRIPTION
🚀 Pull Request
========================

🎯 PR Type
----------
-   [ ] **Feature:** Adds new functionality or user-facing change.
-   [x] **Bug Fix:** Solves a defect or incorrect behavior.
-   [ ] **Refactor:** Improves code structure/readability without changing external behavior.
-   [ ] **Documentation:** Updates to README, Wiki, or internal docs.
-   [ ] **Chore:** Non-code changes (e.g., CI configuration, dependency bumps).

1\. Issue Tracking & Reference
------------------------------
-   **Ticket Number(s):** N/A
-   **Ticket Link(s):** Failing run: https://github.com/newrelic/relibank/actions/runs/26174636501

2\. Summary of Changes
----------------------
The `Build & Push Container Images` workflow's `Deploy to AKS` step was failing with:

```
error: accumulating resources: ... evalsymlink failure on
'/home/runner/work/relibank/relibank/k8s/base/infrastructure/newrelic/nrdot-mssql.env'
: no such file or directory
```

`k8s/base/kustomization.yaml` declares a `secretGenerator` (`nrdot-mssql-credentials`) that pulls from `k8s/base/infrastructure/newrelic/nrdot-mssql.env`. That file is intentionally not checked in — it's normally generated at deploy time by a Skaffold pre-deploy hook (see `skaffold.yaml`). The CI workflow only runs `skaffold build`, so the hook never fires; when the deploy step then runs `kubectl apply -k k8s/overlays/azure-prod`, kustomize cannot resolve the env file and the job aborts before any manifests are applied.

This PR adds a workflow step that materializes `nrdot-mssql.env` from `skaffold.env` before the deploy, mirroring what the Skaffold hook does locally.

-   **Expected Outcome:** The `Deploy to AKS` step in the `Build & Push Container Images` workflow runs to completion against `relibank-prod`. The `nrdot-mssql-credentials` secret is generated by kustomize, the `nrdot-collector-mssql` deployment can mount its env vars, and downstream workflow steps (DB init waits, service restarts, Chaos Mesh, NR observability stack) execute as expected.

### Detailed Change Log & Justification
-   **Change 1:** Added a new `Generate nrdot-mssql.env` step to `.github/workflows/build-push-images.yml`, gated on the same `inputs.deploy` / `inputs.skip_build` condition as the deploy step, placed immediately before `Deploy to AKS`.
    -   **Justification:** Without this file, `kubectl apply -k k8s/overlays/azure-prod` fails on a missing `secretGenerator` source and the deploy never starts. The step sources the workflow-generated `skaffold.env` and writes `MSSQL_NEWRELIC_PASSWORD`, `NEW_RELIC_LICENSE_KEY`, and `NEW_RELIC_OTLP_ENDPOINT` (defaulted to `https://otlp.nr-data.net`) to `k8s/base/infrastructure/newrelic/nrdot-mssql.env`, matching the contract documented in `nrdot-mssql.env.example` and implemented by the Skaffold pre-deploy hook in `skaffold.yaml`.

3\. Testing
-----------

### Testing Strategy
-   **Environment Used:** GitHub Actions (`Build & Push Container Images` workflow against `relibank-prod`).
-   **Production Safety Assessment:** Low risk. The change is isolated to a CI workflow file. The new step only writes a file inside the runner's checkout; it does not modify cluster state, repo source, or any deployable image. The values written are already used by the existing Skaffold hook locally, so behavior in-cluster is unchanged from the intended path. If the step fails, the workflow fails fast before `kubectl apply`, with no partial-state risk.
-   **What areas were NOT tested and why?** Local `skaffold dev` / `skaffold run` paths were not re-tested — the Skaffold pre-deploy hook in `skaffold.yaml` is unchanged, so the local developer flow is unaffected by this PR.

### Coverage Details

| Scenario      | Details                                                                                                                                                | Results                                                                                          |
| ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
| Happy Path    | Re-run `Build & Push Container Images` with `deploy=true` on `relibank-prod`. Confirm the new step runs, the file is written, and `kubectl apply -k` succeeds. | Pending CI run on this branch.                                                                   |
| Edge Case 1   | Run with `skip_build=true` (deploy-only path). The new step shares the same `if:` condition as `Deploy to AKS`, so it must still execute.              | Verified by inspection of the `if:` expression matching `Deploy to AKS`. Pending CI confirmation. |
| Edge Case 2   | Run with `deploy=false` and `skip_build=false` (build-only path). The new step must be skipped so we don't create an unused file.                       | Verified by inspection of the `if:` expression. Pending CI confirmation.                         |

4\. Evidence
------------
-   **Screenshots/Gifs:** N/A
-   **Console/Log Output Snippets:**
    -   Failing run (before fix): https://github.com/newrelic/relibank/actions/runs/26174636501 — `Deploy to AKS` exits 1 with `evalsymlink failure on '.../k8s/base/infrastructure/newrelic/nrdot-mssql.env'`.
    -   Successful run (after fix): _to be attached once this branch runs in CI._
-   **Test Report Links:** N/A — no application code paths changed.

5\. Review and Merge Checklist
------------------------------
-   [x] All blocking review comments from the latest round are **resolved**.
-   [x] This branch has been rebased against the `main` branch and all **merge conflicts are resolved**.
-   [x] The code includes sufficient comments, particularly in complex or non-obvious areas.
-   [x] The code adheres to project **coding standards** (linting, style guides, best practices).
-   [x] Relevant documentation and runbooks have been updated, if necessary.
-   [x] My changes generate no new warnings or errors.
-   [x] My commits are squashed into a single, descriptive commit.
-   [ ] My test results are uploaded as a text file, and new tests were created where required.
