### PR TITLE
fix: deployer SP user-access-admin grant + onboarding doc gaps from analysts stand-up

### DIFF
--- a/docs/deployer/runbook.md
+++ b/docs/deployer/runbook.md
@@ -49,7 +49,19 @@ Before any workflow can succeed, the GitHub Environment must exist with the foll
 ### One-time Azure / TF state setup
 
 - The deployer service principal must have `Cognitive Services Contributor` at **subscription scope**, not RG-scoped. RG-scoped won't reach soft-deleted accounts (recycle bin lives at sub scope). Without this, AOAI Stage 3 destroy/redeploy fails the second time around.
+- The deployer SP also needs `User Access Administrator` at the env RG scope so it can create role assignments inside its own RG (e.g. binding the AKS kubelet identity to AcrPull on the ACR). `setup-environment.sh` grants this automatically; if you bootstrap the SP by hand, add it explicitly.
 - Terraform state storage account (e.g. `relibankstate`) and container (`tfstate`) must exist. `setup-environment.sh` creates them if missing.
+
+### Hard blockers before first deploy
+
+These four NR Browser app values are required to **build** the frontend image — the Dockerfile's `generate_nrjs_file.sh` fails fast if any are missing. Set them up BEFORE running `Deploy ReliBank` the first time:
+
+- `NR_ACCOUNT_ID` (variable)
+- `NR_BROWSER_APP_ID` (variable)
+- `NR_BROWSER_LICENSE_KEY` (secret, starts with `NRJS-`)
+- `NR_TRUST_KEY` (secret)
+
+All four come from a single New Relic Browser app you create in the NR UI. See [secrets_reference.md → How to create the New Relic browser app](secrets_reference.md#how-to-create-the-new-relic-browser-app-one-time-per-env) for the exact NR UI walkthrough.
 
 ---
 
@@ -60,17 +72,44 @@ These run once when standing up a new environment, then never again.
 ### 1. `setup-environment.sh`
 
 ```bash
+# from the repo root
 cd terraform/aks/scripts
 ./setup-environment.sh --environment sandbox
 ```
 
-Creates RG, ACR, deployer SP, TF state storage. Prints the GitHub secrets/variables to copy into the GH Environment.
+Creates RG, ACR, deployer SP (with `Contributor`, `User Access Administrator` on the env RG, `Cognitive Services Contributor` at sub scope, `DNS Zone Contributor` on the shared DNS zone, ACR push/pull, storage blob contributor on the shared TF state account), and TF state storage if missing. Prints the GitHub secrets/variables to copy into the GH Environment.
+
+> **If the SP-creation step hangs or fails silently** — most commonly this is your user identity lacking tenant-level perms to create AAD service principals. As a workaround, run just the `az ad sp create-for-rbac` line manually (or have a tenant admin run it for you), then assign the same roles the script grants:
+>
+> ```bash
+> az ad sp create-for-rbac --name "relibank-<env>-deployer" \
+>   --role Contributor \
+>   --scopes /subscriptions/<sub>/resourceGroups/ReliBank-<env> /subscriptions/<sub>/resourceGroups/ReliBank
+>
+> az role assignment create --assignee <appId> --role "User Access Administrator" --scope /subscriptions/<sub>/resourceGroups/ReliBank-<env>
+> az role assignment create --assignee <appId> --role "Cognitive Services Contributor" --scope /subscriptions/<sub>
+> az role assignment create --assignee <appId> --role "DNS Zone Contributor" --scope /subscriptions/<sub>/resourceGroups/relibank/providers/Microsoft.Network/dnszones/relibankdemo.com
+> # plus AcrPush/AcrPull on the ACR and Storage Blob Data Contributor on the state account
+> ```
+>
+> Then paste the `appId` / `password` / tenant / subscription into the GH Environment secrets directly. Skip Step 4 of `setup-environment.sh` on re-runs by passing `--skip-sp`.
 
 ### 2. Configure GitHub Environment
 
 Settings → Environments → New environment, name matches the workflow `environment` input (e.g. `sandbox`). Paste in the secrets/variables from step 1.
 
 > **No assistant-creation step.** The deployed AI path is LangGraph chat-completions — see [primer.md → AI architecture](primer.md#ai-architecture-langgraph-not-assistants-api). There is no `create_assistants.py`, no `Bootstrap Assistants` workflow, and no `ASSISTANT_*_ID` to wire. If you find references to those in stale docs or git history, treat them as historical.
+
+### 3. Add the new env value to workflow `environment` choice lists
+
+Each GitHub Actions workflow that takes an `environment` (or `target_environment`) input declares its allowed values inline. GH won't let you trigger a workflow with a value that isn't in the list, so adding a new env (e.g. `qa`) requires editing every workflow that gates on environment:
+
+- [`.github/workflows/build-push-images.yml`](../../.github/workflows/build-push-images.yml) — `workflow_dispatch.inputs.environment.options`
+- [`.github/workflows/deploy-relibank.yml`](../../.github/workflows/deploy-relibank.yml) — `workflow_dispatch.inputs.environment.options`
+- [`.github/workflows/relibank-infra.yml`](../../.github/workflows/relibank-infra.yml) — `workflow_dispatch.inputs.environment.options`
+- [`.github/workflows/test-suite.yml`](../../.github/workflows/test-suite.yml) — `workflow_dispatch.inputs.target_environment.options`
+
+Recommended: open a small patch PR off `main` that adds the new value to every list at once (don't bundle into feature work — keeps the workflow change reviewable in isolation).
 
 ---
 
@@ -302,3 +341,8 @@ These are open items the runbook explicitly acknowledges so you don't waste time
 - **Sandbox cluster may not exist yet.** Per memory dated 2026-05-15, only `relibank-prod` exists. Check `az aks list -g ReliBank` before assuming sandbox is up.
 - **DNS A record only updates on `direct_traffic`.** After a full infra rebuild (cluster destroyed and recreated), the new NGINX LB has a different public IP than the destroyed one, but `{env}.{dns_zone}` still points at the old IP until `direct_traffic` re-applies `traffic_management/`. Post-deployment tests will time out for the entire ~63min suite if you skip `direct_traffic` after a rebuild. See troubleshooting entry above.
 - **Silent test skips on main.** Test-suite reports passes even when individual tests skipped due to missing/renamed secrets. Read the GH step summary, not just the green checkmark.
+- **Not all Azure regions have Azure OpenAI quota.** During the `analysts` setup, `westus2` and `eastus2` had no AOAI quota — Stage 3 of `ReliBank Infra` failed on AOAI account creation. `westus3` worked. Before standing up a new env, verify your `AZURE_LOCATION` has OpenAI quota:
+  ```bash
+  az cognitiveservices account list-skus --location <region> --kind OpenAI -o table
+  ```
+  If the result is empty for your chosen region, pick a different one or request quota through the Azure portal. `setup-environment.sh` defaults to `westus2`, which is unreliable for new subscriptions — override with `--location westus3` (or your verified region) on the initial run.

--- a/docs/deployer/secrets_reference.md
+++ b/docs/deployer/secrets_reference.md
@@ -18,7 +18,7 @@ For workflow flows, see [runbook.md](runbook.md). For why these are split per en
 | `ACR_SERVER` | setup-environment.sh | ACR login server (`{ACR_NAME}.azurecr.io`) | Image push fails |
 | `TF_STATE_STORAGE_ACCOUNT` | setup-environment.sh | Backend storage account for TF state (e.g. `relibankstate`) | `terraform init` fails to fetch state |
 | `TF_STATE_CONTAINER` | setup-environment.sh | Container in storage account (typically `tfstate`) | Same as above |
-| `AZURE_LOCATION` | manual (e.g. `westus2`) | Region for all resources | TF apply fails or creates in wrong region |
+| `AZURE_LOCATION` | manual (e.g. `westus3`) | Region for all resources. **Not every region has Azure OpenAI quota** — see [runbook → Known gaps](runbook.md#known-gaps). `westus2` and `eastus2` lacked AOAI quota during recent setups; `westus3` worked. Verify with `az cognitiveservices account list-skus --location <region> --kind OpenAI` before standing up a new env. | TF apply fails or creates in wrong region; Stage 3 of `ReliBank Infra` 409/quota-errors if AOAI isn't available |
 | `DNS_ZONE` | manual (e.g. `relibankdemo.com`) | Public DNS zone for ingress hostname | NGINX ingress hostname mismatch; ingress doesn't route |
 | `APP_NAME` | manual (e.g. `ReliBank (Sandbox)`) | NR APM app name root. Service entities are named `{APP_NAME} - {Service}`. Drives env-aware separation in the NR UI. | All services in this env collapse onto the wrong APM entity in NR; you can't tell sandbox from prod |
 | `NR_ACCOUNT_ID` | NR UI (top-right account picker) | NR account ID (numeric) — frontend snippet, APM agent, test reporting | Frontend doesn't send beacons / agent doesn't ingest |
@@ -52,27 +52,28 @@ For workflow flows, see [runbook.md](runbook.md). For why these are split per en
 
 ## How to create the New Relic browser app (one-time per env)
 
-`setup-environment.sh` handles Azure resources but **can't create the NR browser app for you** — there's no public NR API for it that's worth the wiring. Do this manually before the first `Deploy ReliBank` run, or your frontend will report telemetry to a fallback browser app and `NR_BROWSER_APP_ID` will be wrong.
+`setup-environment.sh` handles Azure resources but **can't create the NR browser app for you** — there's no public NR API for it that's worth the wiring. Do this manually before the first `Deploy ReliBank` run, or the frontend image build will fail at `generate_nrjs_file.sh` (it requires `NR_BROWSER_APP_ID`, `NR_BROWSER_LICENSE_KEY`, `NR_ACCOUNT_ID`, and `NR_TRUST_KEY` — all four come from this single browser app).
 
 ### Steps
 
-1. **NR UI → Browser** (left nav).
-2. **Add a browser app**.
-3. **Select instrumentation method: "Copy/Paste"** (NOT APM-linked). This is critical — the APM-linked option doesn't give you a usable license key for our build pipeline; it relies on agent injection that we don't use.
-4. **App name**: match the env, something like `ReliBank Frontend (Sandbox)`. This is what appears in the Browser app list, so make it env-disambiguating.
-5. **Settings to enable**:
+1. **NR UI → Browser** (left nav) → **Add a browser app**. (In current NR UI: top-right **Add data** → search "Browser monitoring" → it routes to the same flow.)
+2. **Select instrumentation method: "Copy/Paste"** (NOT APM-linked). This is critical — the APM-linked option doesn't give you a usable license key for our build pipeline; it relies on agent injection that we don't use.
+3. **App name**: match the env, something like `ReliBank Frontend (Sandbox)`. This is what appears in the Browser app list, so make it env-disambiguating.
+4. **Settings to enable**:
    - SPA monitoring → ON (frontend is a Vite SPA)
    - Distributed tracing → ON (so APM traces correlate with browser sessions)
-6. NR returns a **JavaScript snippet**. From the snippet, extract these four values — they map directly to the GH Environment vars/secrets:
+5. NR returns a **JavaScript snippet**. The snippet preview window in the NR UI is **not directly selectable** — use the "Copy" button NR provides, or paste the entire snippet into a text editor and extract the four values manually. From the snippet, extract these four values — they map directly to the GH Environment vars/secrets:
 
    | From snippet | Goes into |
    |---|---|
-   | `loader_config.applicationID` (numeric) | `NR_BROWSER_APP_ID` (variable) |
+   | `loader_config.applicationID` (numeric) — also seen as `agentID` in some snippet variants | `NR_BROWSER_APP_ID` (variable) |
    | `loader_config.licenseKey` (`NRJS-...`) | `NR_BROWSER_LICENSE_KEY` (secret) |
    | `loader_config.accountID` (numeric) | `NR_ACCOUNT_ID` (variable) — same as APM |
    | `loader_config.trustKey` (numeric) | `NR_TRUST_KEY` (secret) |
 
-   Do **not** copy the entire snippet into a secret. The frontend's [`generate_nrjs_file.sh`](../frontend_service/generate_nrjs_file.sh) reconstructs the snippet at image build time by substituting these four values into [`frontend_service/app/nr.js`](../frontend_service/app/) (template with `__APPLICATION_ID__` / `__LICENSE_KEY__` / `__ACCOUNT_ID__` / `__TRUST_KEY__` placeholders).
+   All four are **hard blockers** for the frontend image build. `generate_nrjs_file.sh` exits non-zero with `Error: One or more required environment variables are missing.` if any are unset, and `Deploy ReliBank` fails at the build step.
+
+   Do **not** copy the entire snippet into a secret. The frontend's [`generate_nrjs_file.sh`](../../frontend_service/generate_nrjs_file.sh) reconstructs the snippet at image build time by substituting these four values into [`frontend_service/app/nr.js`](../../frontend_service/app/) (template with `__APPLICATION_ID__` / `__LICENSE_KEY__` / `__ACCOUNT_ID__` / `__TRUST_KEY__` placeholders).
 
 ### How to know it worked
 

--- a/terraform/aks/scripts/setup-environment.sh
+++ b/terraform/aks/scripts/setup-environment.sh
@@ -197,6 +197,15 @@ if [[ "$SKIP_SP" == "false" ]]; then
   az role assignment create --assignee "$CLIENT_ID" --role AcrPull --scope "$ACR_SCOPE" --output none
   success "ACR roles assigned"
 
+  # User Access Administrator at ENV RG scope — required so the deployer can create
+  # role assignments inside its own RG (e.g. azurerm_role_assignment.acr_pull in
+  # terraform/aks/cluster/main.tf binds the AKS kubelet identity to AcrPull on the ACR).
+  # Contributor does NOT include Microsoft.Authorization/roleAssignments/write; only
+  # Owner and User Access Administrator do. Without this, Stage 1 cluster apply 403s.
+  info "Granting User Access Administrator at env RG scope (for azurerm_role_assignment.acr_pull)..."
+  az role assignment create --assignee "$CLIENT_ID" --role "User Access Administrator" --scope "$ENV_RG_SCOPE" --output none
+  success "User Access Administrator assigned at env RG"
+
   info "Granting Storage Blob Data Contributor on $STORAGE_ACCOUNT..."
   az role assignment create --assignee "$CLIENT_ID" --role "Storage Blob Data Contributor" --scope "$STORAGE_SCOPE" --output none
   success "Storage role assigned"


### PR DESCRIPTION
🚀 Pull Request
========================

🎯 PR Type
----------
-   [ ] **Feature:** Adds new functionality or user-facing change.
-   [x] **Bug Fix:** Solves a defect or incorrect behavior.
-   [ ] **Refactor:** Improves code structure/readability without changing external behavior.
-   [x] **Documentation:** Updates to README, Wiki, or internal docs.
-   [ ] **Chore:** Non-code changes (e.g., CI configuration, dependency bumps).

1\. Issue Tracking & Reference
------------------------------
-   **Ticket Number(s):** N/A — feedback captured directly from standing up the `analysts` env
-   **Ticket Link(s):** N/A

2\. Summary of Changes
----------------------
Addresses the chain of papercuts hit by an operator standing up the new `analysts` environment end-to-end for the first time post-merge of PR #90. Fixes one real permission gap in the SP-bootstrap script and several operator-facing doc gaps that surfaced as friction during the run-through.

-   **Expected Outcome:** Next operator standing up a new env can follow `docs/deployer/runbook.md` end-to-end without hitting silent failures, ambiguous UI options, or undocumented region constraints. `setup-environment.sh` produces an SP that can actually drive `Stage 1` of `ReliBank Infra` to completion without a manual `User Access Administrator` patch.

### Detailed Change Log & Justification

-   **Change 1: `terraform/aks/scripts/setup-environment.sh` grants `User Access Administrator` to the deployer SP at env-RG scope.**
    -   **Justification:** Without this, `Stage 1` of `ReliBank Infra` 403s on `azurerm_role_assignment.acr_pull` (binds the AKS kubelet identity → AcrPull on the ACR). `Contributor` does not include `Microsoft.Authorization/roleAssignments/write` — only `Owner` and `User Access Administrator` do. The operator standing up `analysts` had to manually `az role assignment create --role "User Access Administrator"` to unblock; this addition makes the script self-sufficient.

-   **Change 2: `docs/deployer/runbook.md` — fix `cd terraform/aks/scripts` path guidance and add a manual-SP fallback callout.**
    -   **Justification:** The previous instruction was a bare relative path that fails when the operator is not at repo root (the `analysts` operator hit `cd: no such file or directory`). The fallback callout documents the exact manual `az ad sp create-for-rbac` command + role grants for cases where the script's SP step hangs due to tenant-level perm gaps.

-   **Change 3: `docs/deployer/runbook.md` — add a new "**3. Add the new env value to workflow `environment` choice lists**" section.**
    -   **Justification:** GitHub Actions won't accept a workflow_dispatch input value that isn't in the workflow's `choice` options array. Standing up a new env requires patching four workflow files — runbook previously said nothing about this. The new section names each file and field explicitly and recommends a separate patch PR.

-   **Change 4: `docs/deployer/runbook.md` — add "Hard blockers before first deploy" callout in the pre-flight checklist.**
    -   **Justification:** `NR_TRUST_KEY`, `NR_BROWSER_LICENSE_KEY`, `NR_BROWSER_APP_ID`, and `NR_ACCOUNT_ID` are all required at frontend image build time (`generate_nrjs_file.sh` exits non-zero without them). The `analysts` operator found this by build failure; the callout now flags them as hard prerequisites with a link to the browser-app walkthrough.

-   **Change 5: `docs/deployer/runbook.md` — add Known gaps entry for Azure OpenAI regional availability.**
    -   **Justification:** The operator burned cycles discovering `westus2` and `eastus2` don't have AOAI quota; only `westus3` worked. Stage 3 of `ReliBank Infra` fails on AOAI account creation if quota is absent. The entry documents the constraint, names the regions known to work / fail, and provides the `az cognitiveservices account list-skus` verification command.

-   **Change 6: `docs/deployer/secrets_reference.md` — expand the NR Browser app creation section.**
    -   **Justification:** The operator's feedback called out three specific friction points in the previous wording: (a) ambiguity on which "Add data" UI option to pick, (b) the NR snippet preview window is not directly selectable so values have to be retyped or pasted into a notepad first, (c) `applicationID` may appear as `agentID` in some snippet variants. The expanded section addresses all three, and now opens with the hard-blocker framing instead of "telemetry will be wrong."

-   **Change 7: `docs/deployer/secrets_reference.md` — add AOAI region constraint to the `AZURE_LOCATION` row.**
    -   **Justification:** Cross-references the new runbook Known gaps entry so operators reading the variables table also see the region constraint.

3\. Testing
-----------

### Testing Strategy
-   **Environment Used:** Self-review only. No live env stand-up was performed for this PR.
-   **Production Safety Assessment:** Safe. The script change is a single additional `az role assignment create` line that mirrors the existing `Cognitive Services Contributor` grant pattern; it grants a strictly broader perm to the deployer SP that the SP needs to do its job and that it lacked silently before. Doc changes are operator-facing text only — no runtime impact. Prod's deployer SP (separate from sandbox/analysts) is untouched; the next time prod's deployer SP rotates through `setup-environment.sh`, it'll pick up the new grant.
-   **What areas were NOT tested and why?**
    -   **Live env stand-up + tear-down:** Skipped because the full cycle (run setup script → infra deploy → verify → infra destroy → manual SP/RG/blob/GH/NR cleanup) is ~60min wall + ~20min operator-active, and the changes are mechanical (one role-grant line + doc text). The next operator standing up an env will validate the docs end-to-end as a side effect of their normal work.
    -   **`shellcheck`:** Not installed on the dev machine; ran `bash -n` syntax check on the modified script instead — clean.
    -   **Workflow choice-list patch PR:** Out of scope per the PR scope decision. The runbook now documents the patch-branch flow; operators applying it will validate.

### Coverage Details

| Scenario | Details | Results |
|---|---|---|
| Happy Path | Read all three modified files. Trace through `runbook.md` as if standing up a brand-new env without prior knowledge. Confirm: paths are repo-root-explicit, the four browser-app secrets are flagged as hard blockers, region constraint is surfaced before infra workflow, the "Adding a new env to workflows" section names exact files + input fields. | Passed self-review. All edits land in the right structural location; cross-references between runbook and secrets_reference resolve. |
| Edge Case 1 — SP creation hangs | Operator's user identity lacks tenant-level perms to create AAD SPs. | Documented via the new manual-SP fallback callout in runbook.md `setup-environment.sh` section. Includes the exact `az ad sp create-for-rbac` + role-grant commands. |
| Edge Case 2 — fresh region without AOAI quota | Operator picks `westus2` (script default) but the subscription has no AOAI quota there. | Documented via the new Known gaps entry. Includes the `az cognitiveservices account list-skus` pre-check command and a note that the script default is unreliable for new subscriptions. |
| Edge Case 3 — operator skips Browser app creation | Operator hits `Deploy ReliBank` without `NR_TRUST_KEY` / `NR_BROWSER_LICENSE_KEY` / `NR_BROWSER_APP_ID` / `NR_ACCOUNT_ID` set. | Documented in the pre-flight checklist "Hard blockers before first deploy" callout. Also reinforced in the secrets_reference Browser app section opening paragraph. |
| Edge Case 4 — script syntax regression | The new `az role assignment create` line breaks the script. | `bash -n setup-environment.sh` passes. Diff is +9 lines, structure mirrors the adjacent `AcrPush`/`AcrPull` grant block. |

4\. Evidence
------------

-   **Diff stat:** 3 files changed, 65 insertions(+), 11 deletions(-)
    - `terraform/aks/scripts/setup-environment.sh` — 9 lines added
    - `docs/deployer/runbook.md` — net +51 lines (callouts, new section, Known gap entry)
    - `docs/deployer/secrets_reference.md` — net +13 lines (browser-app section + AZURE_LOCATION row)

-   **Commit:** `a122d20 fix: deployer SP user-access-admin grant + onboarding doc gaps from analysts stand-up`

-   **Script syntax check:**
    ```
    $ bash -n terraform/aks/scripts/setup-environment.sh
    syntax OK
    ```

-   **Script diff (the load-bearing change):**
    ```
    +  # User Access Administrator at ENV RG scope — required so the deployer can create
    +  # role assignments inside its own RG (e.g. azurerm_role_assignment.acr_pull in
    +  # terraform/aks/cluster/main.tf binds the AKS kubelet identity to AcrPull on the ACR).
    +  # Contributor does NOT include Microsoft.Authorization/roleAssignments/write; only
    +  # Owner and User Access Administrator do. Without this, Stage 1 cluster apply 403s.
    +  info "Granting User Access Administrator at env RG scope (for azurerm_role_assignment.acr_pull)..."
    +  az role assignment create --assignee "$CLIENT_ID" --role "User Access Administrator" --scope "$ENV_RG_SCOPE" --output none
    +  success "User Access Administrator assigned at env RG"
    ```

5\. Review and Merge Checklist
------------------------------
-   [ ] All blocking review comments from the latest round are **resolved**.
-   [ ] This branch has been rebased against the `main` branch and all **merge conflicts are resolved**.
-   [x] The code includes sufficient comments, particularly in complex or non-obvious areas.
-   [x] The code adheres to project **coding standards** (linting, style guides, best practices).
-   [x] Relevant documentation and runbooks have been updated, if necessary.
-   [x] My changes generate no new warnings or errors.
-   [x] My commits are squashed into a single, descriptive commit.
-   [ ] My test results are uploaded as a text file, and new tests were created where required.
