### PR TITLE
feat: new relic module deployer

### DIFF
--- a/.github/workflows/relibank-newrelic.yml
+++ b/.github/workflows/relibank-newrelic.yml
@@ -82,7 +82,61 @@ jobs:
             -var="new_relic_region=${{ vars.NR_REGION || 'US' }}" \
             -var="demo_environment=${{ github.event.inputs.environment }}" \
             -var="app_name=${{ vars.APP_NAME }}" \
+            -var="aks_cluster_name=${{ vars.AKS_CLUSTER_NAME }}" \
+            -var="aks_resource_group=${{ vars.AKS_RESOURCE_GROUP }}" \
             --auto-approve
+
+  # ---------------------------------------------------------------------------
+  # Validate — post-apply, confirm each NR entity is queryable from the API
+  # user's perspective AND that the helm-installed cluster agents are reporting
+  # telemetry. Mirrors demogorgon's post-deployment-validation.yml validate-data
+  # job: pytest + NerdGraph, `continue-on-error: true` step + result-check step
+  # so per-test failures are visible but the overall job still fails as a hard
+  # gate.
+  # ---------------------------------------------------------------------------
+  relibank-newrelic-validate:
+    name: Validate ReliBank NR entities + telemetry
+    if: ${{ github.event.inputs.action_type == 'deploy' }}
+    needs: relibank-newrelic-deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: ${{ github.event.inputs.environment }}
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: pip install pytest requests
+
+      - name: Wait for entity propagation
+        run: |
+          echo "Waiting 120s for NR entity propagation + agent first-report..."
+          sleep 120
+
+      - name: Run NR validation
+        id: nr-validate
+        continue-on-error: true
+        env:
+          NR_USER_API_KEY:  ${{ secrets.NR_USER_API_KEY }}
+          NR_ACCOUNT_ID:    ${{ vars.NR_ACCOUNT_ID }}
+          APP_NAME:         ${{ vars.APP_NAME }}
+          AKS_CLUSTER_NAME: ${{ vars.AKS_CLUSTER_NAME }}
+        run: |
+          python3 -m pytest -v tests/workflow_validation/validate_nr_workflow.py --tb=short --no-header
+
+      - name: Check validation result
+        if: always()
+        run: |
+          if [ "${{ steps.nr-validate.outcome }}" != "success" ]; then
+            echo "::error::NR entity/telemetry validation failed"
+            exit 1
+          fi
 
   # ---------------------------------------------------------------------------
   # Destroy — tear down all entities managed by this module.
@@ -135,4 +189,6 @@ jobs:
             -var="new_relic_region=${{ vars.NR_REGION || 'US' }}" \
             -var="demo_environment=${{ github.event.inputs.environment }}" \
             -var="app_name=${{ vars.APP_NAME }}" \
+            -var="aks_cluster_name=${{ vars.AKS_CLUSTER_NAME }}" \
+            -var="aks_resource_group=${{ vars.AKS_RESOURCE_GROUP }}" \
             --auto-approve

--- a/docs/deployer/deployer_primer.md
+++ b/docs/deployer/deployer_primer.md
@@ -16,12 +16,15 @@ That's the whole macro story. Everything below is "how does the deployer encode 
 
 ---
 
-## The two workflows and why they're split
+## The three workflows and why they're split
+
+The deployer has three top-level workflows, layered `infra → app → new relic`. Each owns a distinct scope and runs on a distinct cadence.
 
 | Workflow | Scope | Run cadence | What it owns |
 |---|---|---|---|
 | [`relibank-infra.yml`](../.github/workflows/relibank-infra.yml) | env-scoped | rarely | Cluster, cluster-wide infra, AOAI, Function App + ACS |
 | [`deploy-relibank.yml`](../.github/workflows/deploy-relibank.yml) | color-scoped | often | One app tier (10 services) per color; image build; traffic switch |
+| [`relibank-newrelic.yml`](../.github/workflows/relibank-newrelic.yml) | env-scoped (third layer) | rare-to-medium | NR entity definitions (dashboards, alerts, SLIs, workloads, synthetics) for the env. Runs AFTER the app tier so it can reference real APM entities via NerdGraph data sources. |
 
 State files mirror the split — see [terraform/aks/](../terraform/aks/):
 
@@ -33,6 +36,7 @@ relibank/{env}/notifications.tfstate      ← infra workflow, Stage 4
 relibank/{env}/blue.tfstate               ← deploy workflow (blue)
 relibank/{env}/green.tfstate              ← deploy workflow (green)
 relibank/{env}/traffic_management.tfstate ← deploy workflow (direct_traffic)
+relibank/{env}/newrelic.tfstate           ← newrelic workflow (third layer)
 ```
 
 ### The split is load-bearing — the blue/green isolation rule
@@ -69,6 +73,31 @@ Run in order on a fresh deploy; controlled by the `stage` input.
 | `post-deployment-tests` | Calls [`test-suite.yml`](../.github/workflows/test-suite.yml) workflow_call — runs Python + frontend tests against the freshly deployed color. |
 | `direct-traffic-relibank` | TF apply on [`terraform/aks/traffic_management`](../terraform/aks/traffic_management/) to flip the NGINX main rule. Sub-second cutover, no pod restart. The canary ingress (X-Test-Env header) lets you smoke-test the inactive color before flipping. |
 | `destroy-relibank` | Destroys app tier in one color. Use after traffic has been switched away. |
+
+---
+
+## The third layer: NR entities
+
+`relibank-newrelic.yml` sits conceptually above the app: `infra → app → new relic`. It manages two things in one apply:
+
+1. **NR entities** — dashboards, alert policies, NRQL conditions, notification destinations/channels/workflows, service levels (SLIs), synthetics monitors, workloads, and entity tags. Mirrors demogorgon's `applications/microservices-demo/terraform/newrelic/newrelic/` module: one file per entity type under [terraform/aks/newrelic](../terraform/aks/newrelic/).
+2. **Cluster-side NR observability stack** — the `nri-bundle` helm chart (infrastructure agent, kube-state-metrics, kubeEvents, logging, prometheus) plus the `nr-ebpf-agent` helm chart for service-level workload metrics. Installed into the `newrelic` namespace (created by [infra/main.tf](../terraform/aks/infra/main.tf)) via `data.azurerm_kubernetes_cluster` credentials passed to the `helm` + `kubernetes` providers. See [nr_infra_agent.tf](../terraform/aks/newrelic/nr_infra_agent.tf). Mirrors demogorgon's `terraform/modules/infra/eks_newrelic/` helm releases.
+
+| Job | What it does |
+|---|---|
+| `relibank-newrelic-deploy` | TF apply on [`terraform/aks/newrelic`](../terraform/aks/newrelic/). Provisions NR entities via the `newrelic/newrelic` provider AND installs the cluster-side helm charts via the `helm`/`kubernetes` providers, in one apply. Idempotent — safe to re-run anytime. |
+| `relibank-newrelic-validate` | Hard-gating post-apply check. Waits 120s for entity propagation + agent first-report, then runs [`tests/workflow_validation/validate_nr_workflow.py`](../tests/workflow_validation/validate_nr_workflow.py) — NerdGraph entity-search for each TF-created entity (dashboard, alert policy, NRQL condition, notification destination/channel, workflow, workload, synthetics monitors) and NRQL for K8sClusterSample/K8sPodSample to confirm the helm-installed agents are reporting. Mirrors demogorgon's `post-deployment-validation.yml` validate-data job. Only runs on `deploy`. |
+| `relibank-newrelic-destroy` | TF destroy. Run BEFORE app-tier destroy so APM data sources still resolve cleanly, AND before infra-tier destroy so the helm releases tear down before the cluster goes away. |
+
+### Why it's a third layer, not a stage of infra
+
+NR entities are env-scoped (one set per env, same as cluster/AOAI/notifications), but they depend on the running app tier: the placeholder data sources in [`nr_entities.tf`](../terraform/aks/newrelic/nr_entities.tf) resolve real APM entities by name (e.g. `${APP_NAME} - Support Service`), which only exist in NR after services report telemetry. That dependency on the app tier rules out putting NR in `relibank-infra.yml` (which runs BEFORE app deploy). And mixing it into `deploy-relibank.yml` would couple env-scoped resources into a color-scoped workflow — wrong scope. A separate top-level workflow keeps each workflow's scope clean.
+
+The trade-off vs demogorgon: demogorgon has a single monolithic `deploy-demogorgon.yml` with `newrelic_deploy` / `newrelic_destroy` as `action_type` values alongside app deploys, and operators are forced to pick a `target_color` even for NR actions (the input is ignored by NR jobs). ReliBank splits this out as its own workflow, which avoids the color-picker quirk. Migrating to demogorgon's pattern later is cheap (TF module unchanged; only workflow plumbing moves).
+
+### Stub-now-fill-in-later
+
+The current `terraform/aks/newrelic/` module ships placeholder stubs (one resource per entity type) so `terraform apply` succeeds end-to-end on a fresh env. Every file is marked with a single `# TMM:` line at the top calling out what to replace. TMM (the entity-management team) replaces these with real definitions over time without needing to touch the workflow or backend wiring. Dashboard JSON and synthetics-script bodies live in [`terraform/aks/newrelic/dashboards/`](../terraform/aks/newrelic/dashboards/) and [`terraform/aks/newrelic/scripts/`](../terraform/aks/newrelic/scripts/) respectively — TMM adds new template files there rather than editing the `.tf` files (mirrors demogorgon's `terraform/newrelic/{dashboards,scripts}/` layout).
 
 ---
 

--- a/docs/deployer/runbook.md
+++ b/docs/deployer/runbook.md
@@ -4,14 +4,15 @@ Operational guide. If you're deploying, switching traffic, or recovering from a 
 
 ---
 
-## TL;DR — the four flows
+## TL;DR — the five flows
 
 | Goal | Workflows in order |
 |---|---|
-| Brand-new environment | `ReliBank Infra` (deploy, stage=all) → `Deploy ReliBank` (deploy, blue) → `Deploy ReliBank` (direct_traffic, blue) |
-| Rolling release | `Deploy ReliBank` (deploy, inactive color) → optional canary verify → `Deploy ReliBank` (direct_traffic, new color) → `Deploy ReliBank` (destroy, old color) |
+| Brand-new environment | `ReliBank Infra` (deploy, stage=all) → `Deploy ReliBank` (deploy, blue) → `Deploy ReliBank` (direct_traffic, blue) → *(once services are reporting)* `ReliBank NR` (deploy) |
+| Rolling release | `Deploy ReliBank` (deploy, inactive color) → optional canary verify → `Deploy ReliBank` (direct_traffic, new color) → `Deploy ReliBank` (destroy, old color). NR entities don't change on rolling release — entity team triggers `ReliBank NR` (deploy) separately when they merge entity changes. |
 | Infra-only refresh | `ReliBank Infra` (deploy, stage=`ai_services` or `notifications`) |
-| Full teardown | `Deploy ReliBank` (destroy) for each color → `ReliBank Infra` (destroy) |
+| NR entities + cluster agent refresh | `ReliBank NR` (deploy) — env-scoped, runs against the same NR account the app reports to. Installs/updates the cluster-side `nri-bundle` + `nr-ebpf-agent` helm charts and refreshes NR entity definitions in one apply. A follow-up `relibank-newrelic-validate` job hard-gates the workflow by NerdGraph-querying each entity and the cluster's K8sClusterSample/K8sPodSample telemetry. Requires at least one color is deployed and services are reporting (entity data sources resolve real APM entities by name). |
+| Full teardown | `ReliBank NR` (destroy) → `Deploy ReliBank` (destroy) for each color → `ReliBank Infra` (destroy). The NR-first ordering is load-bearing: the NR module's helm releases live on the cluster, so `ReliBank Infra` destroy (which tears down the cluster) would orphan that state. |
 
 ---
 
@@ -41,7 +42,7 @@ Before any workflow can succeed, the GitHub Environment must exist with the foll
 | `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` / `AZURE_SUBSCRIPTION_ID` / `AZURE_TENANT_ID` | Same SP, broken out for `azurerm` provider |
 | `NR_LICENSE_KEY` | APM ingest, ends in `FFFFNRAL` |
 | `NR_BROWSER_LICENSE_KEY` | Browser ingest, starts with `NRJS-`. **Different key from above.** See troubleshooting if MFE telemetry breaks. |
-| `NR_USER_API_KEY` | NerdGraph user key for tests/automation |
+| `NR_USER_API_KEY` | NerdGraph user key. Used by tests, scenario flows, AND the `ReliBank NR` workflow's TF module to CRUD NR entities (dashboards, alerts, SLIs, workloads, synthetics). Must start with `NRAK-`. |
 | `MSSQL_SA_USER` / `MSSQL_SA_PASSWORD` | MSSQL admin |
 | `POSTGRES_USER` / `POSTGRES_PASSWORD` | Postgres admin |
 | `AZURE_ACS_SMS_PHONE_NUMBER` | Sender phone for SMS |
@@ -94,6 +95,12 @@ Settings → Environments → New environment, name matches the workflow `enviro
    - `environment=sandbox`
    - `target_color=blue`
    - Sub-second NGINX rule flip. App is now live.
+4. *(Wait ~1-2 min for services to start reporting to NR.)*
+5. **`ReliBank NR`** workflow_dispatch
+   - `action_type=deploy`
+   - `environment=sandbox`
+   - Provisions placeholder NR entities (dashboard, alert policy, SLI, workload, synthetics, etc.) under `${APP_NAME} - Placeholder *`. The entity team replaces these with real definitions over time. **Required before this step:** APM entities must exist in NR — that means at least one color is deployed and services are actively reporting, otherwise the data sources in `terraform/aks/newrelic/nr_entities.tf` fail to resolve at plan time.
+   - After apply, `relibank-newrelic-validate` waits 120s then runs [`tests/workflow_validation/validate_nr_workflow.py`](../../tests/workflow_validation/validate_nr_workflow.py) — NerdGraph entity-search per TF-created entity (dashboard/alert policy/NRQL condition/destination/channel/workflow/workload/synthetics monitors) and NRQL for `K8sClusterSample` + `K8sPodSample` on the `newrelic` namespace. Any check failing fails the workflow. If a telemetry check fails, give the agents another minute and re-run the workflow (a clean re-apply is a no-op against state).
 
 ### Rolling release (env on blue, deploying green)
 
@@ -129,11 +136,20 @@ When build args (NR keys, Stripe keys, browser license key) change but source ha
 
    This is a known gap. See [Known gaps](#known-gaps).
 
+### NR entities refresh
+
+When the entity team merges entity-definition changes under `terraform/aks/newrelic/`, the changes don't apply automatically — trigger them explicitly:
+
+1. **`ReliBank NR`** — `action_type=deploy`, pick the env. Idempotent; safe to re-run anytime.
+
+If a stub data source in `nr_entities.tf` doesn't resolve (e.g. you added a new service reference before that service was deployed), TF apply fails at plan time. Deploy the missing service first, wait 1-2 min, retry.
+
 ### Full teardown
 
-1. **`Deploy ReliBank`** — `action_type=destroy`, `target_color=blue`
-2. **`Deploy ReliBank`** — `action_type=destroy`, `target_color=green`
-3. **`ReliBank Infra`** — `action_type=destroy`. Pre-destroy-checks confirms both color namespaces are empty before allowing infra destroy.
+1. **`ReliBank NR`** — `action_type=destroy`. Removes the env's NR entities before the APM data sources go stale (which they do once the app tier stops reporting).
+2. **`Deploy ReliBank`** — `action_type=destroy`, `target_color=blue`
+3. **`Deploy ReliBank`** — `action_type=destroy`, `target_color=green`
+4. **`ReliBank Infra`** — `action_type=destroy`. Pre-destroy-checks confirms both color namespaces are empty before allowing infra destroy.
 
 ---
 

--- a/docs/deployer/secrets_reference.md
+++ b/docs/deployer/secrets_reference.md
@@ -25,6 +25,7 @@ For workflow flows, see [runbook.md](runbook.md). For why these are split per en
 | `NR_BROWSER_APP_ID` | NR UI → Browser → app → Settings | `applicationID` from the browser app's JS snippet | Beacons land on wrong browser app, MFE telemetry breaks silently |
 | `SMS_THROTTLE_PERCENTAGE` | manual (default `5`) | Percentage of SMS sends actually delivered through ACS (rest are no-op'd to avoid Azure charges) | Real SMS to real numbers if too high; 0 SMS if too low |
 | `NR_ACCOUNT_ID_ALERTS` | NR UI | Optional — separate NR account for alerting flows. Used only by `flow-stress-chaos.yml` | Alert demo flows fire on wrong account |
+| `NR_REGION` | manual (`US` or `EU`) | Optional — defaults to `US` in the `ReliBank NR` workflow if unset. Override only if the env's NR account lives in the EU region. | `newrelic/newrelic` provider authenticates against the wrong region; entity CRUD silently lands on the wrong NR account or fails. |
 
 ---
 
@@ -37,9 +38,9 @@ For workflow flows, see [runbook.md](runbook.md). For why these are split per en
 | `AZURE_CLIENT_SECRET` | setup-environment.sh | SP secret — `ARM_CLIENT_SECRET` | Same as above |
 | `AZURE_SUBSCRIPTION_ID` | setup-environment.sh | `ARM_SUBSCRIPTION_ID` | TF apply targets wrong subscription |
 | `AZURE_TENANT_ID` | setup-environment.sh | `ARM_TENANT_ID` | TF auth fails |
-| `NR_LICENSE_KEY` | NR UI → API keys → Ingest – License | **APM** ingest. Server-side agents send traces/metrics with this. Format: `<32 hex chars>FFFFNRAL`. | No APM data in NR for any service |
+| `NR_LICENSE_KEY` | NR UI → API keys → Ingest – License | **APM** ingest. Server-side agents send traces/metrics with this. Also injected into the cluster-side `nri-bundle` / `nr-ebpf-agent` helm charts installed by `relibank-newrelic.yml`. Format: `<32 hex chars>FFFFNRAL`. | No APM data in NR for any service; no cluster-side infrastructure/Kubernetes/logging/prometheus telemetry either |
 | `NR_BROWSER_LICENSE_KEY` | NR UI → Browser → app → Settings → JS snippet → `licenseKey` | **Browser** ingest. Frontend `nr.js` snippet uses this. Format: `NRJS-<20 hex chars>`. **Different key from `NR_LICENSE_KEY`** — not auto-derivable. | If you wire APM key here: `PageView` events leak to NR account default app, `MicroFrontEndTiming` and `.register()` events silently drop, MFE telemetry tests fail |
-| `NR_USER_API_KEY` | NR UI → API keys → User | NerdGraph queries from tests + scenario flows | Test suite reports skip/false-pass on NR-querying tests |
+| `NR_USER_API_KEY` | NR UI → API keys → User | NerdGraph queries from tests + scenario flows. **Also drives the `ReliBank NR` workflow's TF module** — the `newrelic/newrelic` provider uses this for entity CRUD (dashboards, alerts, SLIs, workloads, synthetics). Must start with `NRAK-`. | Test suite reports skip/false-pass on NR-querying tests; `ReliBank NR` workflow fails at provider init. |
 | `NR_TRUST_KEY` | NR UI → Browser → app → JS snippet → `trustKey` | Parent account in NR org hierarchy (for cross-app browser linkage) | Browser app can't link to APM, distributed tracing in browser broken |
 | `MSSQL_SA_USER` | manual (typically `SA`) | MSSQL admin username | DB connections fail |
 | `MSSQL_SA_PASSWORD` | manual | MSSQL admin password (must meet MSSQL complexity policy) | DB connections fail; container may refuse to start |
@@ -108,5 +109,6 @@ If you need to trace where something gets used:
 | [`build-push-images.yml`](../.github/workflows/build-push-images.yml) | `NR_LICENSE_KEY`, `NR_BROWSER_LICENSE_KEY`, `NR_USER_API_KEY`, `NR_TRUST_KEY`, `NR_ACCOUNT_ID`, `NR_BROWSER_APP_ID`, `APP_NAME`, ACR vars |
 | [`relibank-infra.yml`](../.github/workflows/relibank-infra.yml) | All Azure secrets, `AZURE_LOCATION`, `AZURE_ACS_SMS_PHONE_NUMBER`, `SMS_THROTTLE_PERCENTAGE`, `AKS_CLUSTER_NAME`, `AKS_RESOURCE_GROUP`, TF state vars |
 | [`deploy-relibank.yml`](../.github/workflows/deploy-relibank.yml) | All Azure secrets, MSSQL/Postgres secrets, `DNS_ZONE`, AKS vars, TF state vars |
+| [`relibank-newrelic.yml`](../.github/workflows/relibank-newrelic.yml) | All Azure secrets (state backend only), `NR_ACCOUNT_ID`, `NR_USER_API_KEY`, `NR_LICENSE_KEY`, `NR_REGION`, `APP_NAME`, TF state vars |
 | [`test-suite.yml`](../.github/workflows/test-suite.yml) | `NR_USER_API_KEY`, `NR_ACCOUNT_ID` |
 | [`generate_nrjs_file.sh`](../frontend_service/generate_nrjs_file.sh) | `NR_BROWSER_APP_ID`, `NR_BROWSER_LICENSE_KEY`, `NR_ACCOUNT_ID`, `NR_TRUST_KEY` (passed via Dockerfile build args) |

--- a/terraform/aks/newrelic/README.md
+++ b/terraform/aks/newrelic/README.md
@@ -1,0 +1,309 @@
+# ReliBank — New Relic entities
+
+This directory is owned by the entity-management team (TMM). It defines every New Relic entity attached to ReliBank — dashboards, alert policies, NRQL conditions, notification destinations/channels, workflows, workloads, service levels (SLIs), synthetics monitors, and entity tags — as Terraform. When the `ReliBank NR` workflow runs, the entities in here are created/updated in New Relic.
+
+You do NOT need to touch the workflow plumbing or anything outside this directory. This README explains:
+
+- [Quick Terraform primer](#quick-terraform-primer) — read this first if you've never used Terraform.
+- [File layout](#file-layout) — which file owns which entity type.
+- [Updating a placeholder](#updating-a-placeholder) — step-by-step recipe.
+- [Making entities env-aware](#making-entities-env-aware) — same TF file applies to sandbox, staging, prod; how values differ per env.
+- [Testing new entities](#testing-new-entities) — every entity should have a post-apply validation check.
+
+---
+
+## Quick Terraform primer
+
+Five-minute version. Skip if you've already worked with Terraform.
+
+### Resources
+
+A **resource** block says "I want this thing to exist in New Relic." Terraform calls the New Relic API to create it on `apply`, and remembers it in a state file so the next `apply` knows whether to update or skip. Example from [`nr_alerts.tf`](nr_alerts.tf):
+
+```hcl
+resource "newrelic_alert_policy" "placeholder" {
+  name                = "${var.app_name} - Placeholder Policy"
+  incident_preference = "PER_CONDITION"
+  account_id          = var.new_relic_account_id
+}
+```
+
+- `newrelic_alert_policy` — the **resource type** (provider-defined; you don't invent these — they come from the `newrelic/newrelic` provider docs at https://registry.terraform.io/providers/newrelic/newrelic/latest/docs).
+- `"placeholder"` — the **local label**. Used to reference this block from other TF code (`newrelic_alert_policy.placeholder.id`). Has nothing to do with the entity name in NR.
+- `name`, `incident_preference`, `account_id` — **arguments**. The provider docs list what each resource type accepts.
+
+The full list of resource types supported by the New Relic provider is at https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources. When you want to add a new entity type, look it up there to see the argument shape.
+
+### Variables
+
+A **variable** is a parameter passed into the module from the outside. Variables are declared in [`variables.tf`](variables.tf):
+
+```hcl
+variable "app_name" {
+  description = "NR APM display root, e.g. `ReliBank (Sandbox)`."
+  type        = string
+}
+```
+
+…and consumed elsewhere with `${var.app_name}`:
+
+```hcl
+name = "${var.app_name} - Placeholder Policy"
+```
+
+When `${var.app_name}` is `ReliBank (Sandbox)`, the resulting NR entity is named `ReliBank (Sandbox) - Placeholder Policy`. When the same TF code runs against `prod`, `${var.app_name}` is `ReliBank (Prod)` instead and the entity is named accordingly — same TF, different value, different entity per environment.
+
+### How variables flow in this project
+
+Three places, in order:
+
+```
+┌─────────────────────────┐
+│  GH Environment         │   per-env values live here. Sandbox has its own copy of every var/
+│  (Settings → Envs)      │   secret; prod has its own copy with different values.
+└────────────┬────────────┘
+             │  ${{ vars.APP_NAME }}  /  ${{ secrets.NR_USER_API_KEY }}
+             ▼
+┌─────────────────────────┐
+│  .github/workflows/     │   the workflow reads the GH Environment vars/secrets and passes
+│  relibank-newrelic.yml  │   them in via `-var="app_name=..." -var="new_relic_..."`
+└────────────┬────────────┘
+             │  terraform apply -var="app_name=ReliBank (Sandbox)" ...
+             ▼
+┌─────────────────────────┐
+│  terraform/aks/newrelic │   variables.tf declares which vars this module accepts.
+│  variables.tf + *.tf    │   nr_*.tf files consume them via `${var.app_name}`.
+└─────────────────────────┘
+```
+
+The variables relibank-newrelic.yml already passes are documented in [`variables.tf`](variables.tf). Most importantly:
+
+| Variable | Value (example) | What it does |
+|---|---|---|
+| `app_name` | `ReliBank (Sandbox)` | Prefix for placeholder entity names. Different per env → different entity names per env. |
+| `demo_environment` | `sandbox` / `staging` / `prod` | Used in entity tags, synthetics URLs, etc. |
+| `new_relic_account_id` | `1234567` | Which NR account to write entities to. |
+| `new_relic_user_api_key` | (secret) | NerdGraph auth. |
+| `new_relic_license_key` | (secret) | Used by the cluster-side helm agents. |
+| `new_relic_region` | `US` / `EU` | NR region. |
+| `aks_cluster_name` | `relibank-sandbox` | AKS cluster name for the helm install + cluster telemetry queries. |
+| `aks_resource_group` | `ReliBank` | AKS RG. |
+
+### `${...}` interpolation
+
+`"${...}"` injects a value into a string. Common shapes:
+
+- `"${var.app_name} - Latency"` → the value of a variable.
+- `"${data.newrelic_entity.support_service.guid}"` → a field from a data source (a "look this up" query).
+- `"${newrelic_alert_policy.placeholder.id}"` → a field from another resource. Terraform infers an ordering dependency from this — `placeholder` is created first.
+
+You can also use a value directly without quotes when it's the whole expression:
+
+```hcl
+policy_id = newrelic_alert_policy.placeholder.id
+```
+
+Both forms work. Use bare references when the value isn't being embedded in a larger string; use `"${...}"` when it is.
+
+---
+
+## File layout
+
+One file per entity type. Find the file that matches what you're adding, drop a new resource block in.
+
+| File | Owns | NR resource types used |
+|---|---|---|
+| [`nr_alerts.tf`](nr_alerts.tf) | Policies, NRQL conditions, destinations, channels, workflows | `newrelic_alert_policy`, `newrelic_nrql_alert_condition`, `newrelic_notification_destination`, `newrelic_notification_channel`, `newrelic_workflow` |
+| [`nr_dashboards.tf`](nr_dashboards.tf) | Dashboards (JSON-backed) | `newrelic_one_dashboard_json` — JSON body lives in [`dashboards/*.json.tftpl`](dashboards/) |
+| [`nr_synthetics.tf`](nr_synthetics.tf) | Ping + script monitors | `newrelic_synthetics_monitor`, `newrelic_synthetics_script_monitor` — script body lives in [`scripts/*.tftpl`](scripts/) |
+| [`nr_workloads.tf`](nr_workloads.tf) | Workloads | `newrelic_workload` |
+| [`nr_service_levels.tf`](nr_service_levels.tf) | Service levels (SLIs) | `newrelic_service_level` |
+| [`nr_entity_tags.tf`](nr_entity_tags.tf) | Tag assignments on existing entities | `newrelic_entity_tags` |
+| [`nr_entities.tf`](nr_entities.tf) | Data-source lookups for APM/Browser entities (not entities created here) | `data "newrelic_entity"` blocks |
+
+Files you should NOT edit (deployer plumbing):
+
+- [`main.tf`](main.tf) — provider configuration.
+- [`variables.tf`](variables.tf) — variable declarations. You DO edit this when [adding a new per-env variable](#adding-a-new-per-env-variable).
+- [`backend.tf`](backend.tf), [`outputs.tf`](outputs.tf) — state backend + module outputs.
+- [`nr_infra_agent.tf`](nr_infra_agent.tf) — installs the cluster-side NR observability agents (helm). Owned by the deployer team.
+
+---
+
+## Updating a placeholder
+
+Recipe, using a new dashboard as the worked example. The same shape applies to every entity type — copy the existing placeholder block, rename, edit.
+
+### 1. Drop a JSON template in `dashboards/`
+
+Save your dashboard JSON as [`dashboards/<name>.json.tftpl`](dashboards/) — e.g. `dashboards/transaction_overview.json.tftpl`. Keep the `${app_name}` / `${account_id}` template variables consistent with the existing placeholder so the dashboard's `name` field renders correctly. To export an existing dashboard from the NR UI:
+
+1. NR UI → Dashboards → open the dashboard.
+2. `...` menu → Copy JSON to clipboard.
+3. Paste into `dashboards/<name>.json.tftpl`.
+4. Replace the hardcoded `accountId` with `${account_id}` and the title prefix with `${app_name}` (so the same JSON template can render per-env names).
+
+### 2. Wire it up in [`nr_dashboards.tf`](nr_dashboards.tf)
+
+Add a new resource block underneath the existing `placeholder` one. Copy the same shape — only `resource` label, the path to the JSON, and the template-var set change:
+
+```hcl
+resource "newrelic_one_dashboard_json" "transaction_overview" {
+  json = templatefile("${path.module}/dashboards/transaction_overview.json.tftpl", {
+    app_name             = var.app_name
+    account_id           = tonumber(var.new_relic_account_id)
+    support_service_guid = data.newrelic_entity.support_service.guid
+  })
+}
+```
+
+`templatefile(path, vars)` is a Terraform built-in — it reads the file at `path`, substitutes the `${...}` placeholders inside using `vars`, and returns the rendered string. Add or remove keys from the `vars` map as needed.
+
+### 3. Add a test (see [Testing new entities](#testing-new-entities) below).
+
+### 4. Open a PR, get it merged, trigger the workflow.
+
+TMM does not run `terraform apply` manually. After merge, trigger the `ReliBank NR` workflow with `action_type=deploy environment=<env>` — the workflow applies the change and runs validation. Repeat per environment.
+
+### Other entity types
+
+Same shape: copy the existing placeholder block in the relevant `nr_*.tf` file, rename the resource label, edit the arguments. The argument shapes come from the provider docs at https://registry.terraform.io/providers/newrelic/newrelic/latest/docs/resources/<resource_name>.
+
+Two patterns worth knowing:
+
+- **Resources that reference other resources** (e.g. an NRQL alert condition needs the policy ID) use `<resource_type>.<label>.<field>`:
+
+  ```hcl
+  policy_id = newrelic_alert_policy.placeholder.id
+  ```
+
+  Terraform figures out the ordering from this — the policy will be created before the condition.
+
+- **Resources that reference NR entities created outside this module** (e.g. an APM service) use the `data` blocks in [`nr_entities.tf`](nr_entities.tf). Add a new `data "newrelic_entity" "<name>"` block per service you need to reference, then use `data.newrelic_entity.<name>.guid` to get its GUID. Note: data sources resolve at plan time, which means the APM entity must already exist in NR — the app tier must be deployed and reporting before this module's apply will succeed.
+
+---
+
+## Making entities env-aware
+
+The same `.tf` files in this directory apply to **sandbox, staging, prod, and analysts**. The differences between environments come from variables. There are two situations:
+
+### Using existing per-env variables
+
+The variables listed in the [variables flow table](#how-variables-flow-in-this-project) — `app_name`, `demo_environment`, `new_relic_account_id`, etc. — are already per-env. **You don't need to do anything extra to use them.** Just interpolate:
+
+```hcl
+name = "${var.app_name} - My New Dashboard"   # → "ReliBank (Prod) - My New Dashboard" in prod
+```
+
+When the workflow runs against `prod`, the value of `var.app_name` is whatever the prod GH Environment has set — different from sandbox, automatically.
+
+### Adding a NEW per-env variable
+
+When you need a value that should differ per environment but isn't already exposed (e.g. a per-env alert threshold, a per-env Slack channel), add a new variable. Three steps:
+
+#### Step 1 — Declare the variable in [`variables.tf`](variables.tf)
+
+```hcl
+variable "transaction_error_rate_threshold" {
+  description = "Critical-alert threshold for transaction-service error rate (%). Different per env."
+  type        = number
+}
+```
+
+Optional: add `default = 5` if there's a sensible default and you don't want every env to set it explicitly.
+
+#### Step 2 — Pass the value in [`.github/workflows/relibank-newrelic.yml`](../../../.github/workflows/relibank-newrelic.yml)
+
+In **both** the apply and destroy steps, add a new `-var=` line:
+
+```yaml
+-var="transaction_error_rate_threshold=${{ vars.TRANSACTION_ERROR_RATE_THRESHOLD }}" \
+```
+
+#### Step 3 — Set the per-env value in each GH Environment
+
+GitHub → repo → *Settings → Environments → `sandbox`* → *Variables* → add `TRANSACTION_ERROR_RATE_THRESHOLD = 5`. Repeat for `staging`, `prod`, `analysts` with whatever value each env should use.
+
+#### Step 4 — Consume the variable in the relevant `.tf` file
+
+```hcl
+resource "newrelic_nrql_alert_condition" "transaction_error_rate" {
+  # ...
+  critical {
+    operator  = "above"
+    threshold = var.transaction_error_rate_threshold
+    # ...
+  }
+}
+```
+
+### When to use a variable vs a hardcoded value
+
+Use a variable when the value is **expected to differ per environment** (thresholds, contacts, target URLs) or **expected to change without a code review** (Slack channel, on-call email). Hardcode when the value is the same everywhere and conceptually part of the entity definition (an SLI's NRQL query, an alert's `incident_preference`).
+
+---
+
+## Testing new entities
+
+Every new entity should have a post-apply check in [`../../tests/workflow_validation/validate_nr_workflow.py`](../../../tests/workflow_validation/validate_nr_workflow.py). The `relibank-newrelic-validate` job runs this file after every deploy as a hard gate — if your new entity isn't queryable in NR within ~120 seconds of `terraform apply` finishing, the workflow fails.
+
+### How the validation file is structured
+
+The file has a NerdGraph helper at the top and one `def test_*` function per check. Each test either:
+
+1. Queries NR for the entity by name.
+2. Asserts at least one match.
+
+Failure → the test fails → the validation job fails → the workflow fails.
+
+### Pick the right query shape for your entity type
+
+| Entity type | Query shape (helper used) | Example test function |
+|---|---|---|
+| Dashboard | `entitySearch` with `type = 'DASHBOARD'` | `test_dashboard_entity_exists` |
+| Workload | `entitySearch` with `type = 'WORKLOAD'` | `test_workload_entity_exists` |
+| Synthetic monitor (ping or script) | `entitySearch` with `type = 'MONITOR'` | `test_synthetics_ping_monitor_exists` |
+| Alert policy | `alerts.policiesSearch` | `test_alert_policy_exists` |
+| NRQL alert condition | `alerts.nrqlConditionsSearch` | `test_nrql_alert_condition_exists` |
+| Notification destination | `aiNotifications.destinations` | `test_notification_destination_exists` |
+| Notification channel | `aiNotifications.channels` | `test_notification_channel_exists` |
+| Workflow | `aiWorkflows.workflows` | `test_workflow_exists` |
+| Service level (SLI) | (not currently exercised — see [Out of scope](#out-of-scope)) | — |
+
+For data-presence checks (e.g. "this dashboard's main query returns rows"), use NRQL via the `run_nrql(nrql)` helper.
+
+### Recipe: add a test for your new entity
+
+1. Open [`validate_nr_workflow.py`](../../../tests/workflow_validation/validate_nr_workflow.py).
+2. Find the existing `def test_*` for an entity of the same type — copy the whole function.
+3. Rename it (`test_transaction_overview_dashboard_exists`) and update the entity name in the assertion (`"${APP_NAME} - Transaction Overview"`). Keep the query shape — the helper functions handle the GraphQL.
+4. Commit alongside the `.tf` change in the same PR.
+
+Worked example — adding the test for the `transaction_overview` dashboard from earlier:
+
+```python
+def test_transaction_overview_dashboard_exists():
+    """`newrelic_one_dashboard_json.transaction_overview` — Dashboard, queried via entitySearch."""
+    assert_entity_exists(f"{APP_NAME} - Transaction Overview", "DASHBOARD")
+```
+
+That's it. Two lines.
+
+### Verifying locally
+
+You can't easily run this script locally without API keys and a live NR account. The workflow run is the test loop — push, trigger, watch. If the validate job fails, the pytest output in the job log shows exactly which check failed and what name it looked for.
+
+### Out of scope
+
+- **Service levels (SLIs)** are not currently validated by `validate_nr_workflow.py` — they need a different query shape (SLI list on the parent workload). Add when needed; the placeholder SLI in [`nr_service_levels.tf`](nr_service_levels.tf) is the only one today.
+- **Data-presence checks** (e.g. "the dashboard returns data for the chart") are heavier — they need real traffic against the cluster. Use the existing app-tier test suite (`test-suite.yml`) for those rather than this validation script.
+
+---
+
+## See also
+
+- [`../../../docs/deployer/deployer_primer.md`](../../../docs/deployer/deployer_primer.md) — full deployer architecture, including the three-layer model and why NR is its own workflow.
+- [`../../../docs/deployer/runbook.md`](../../../docs/deployer/runbook.md) — operational runbook: trigger order, common workflows.
+- [`../../../docs/deployer/secrets_reference.md`](../../../docs/deployer/secrets_reference.md) — every GH Environment variable and secret consumed by the deployer.
+- demogorgon's `applications/microservices-demo/terraform/newrelic/newrelic/` module — the internal reference layout this directory mirrors. Use it as a richer example of real (non-placeholder) entity definitions.
+- New Relic Terraform provider docs — https://registry.terraform.io/providers/newrelic/newrelic/latest/docs.

--- a/terraform/aks/newrelic/backend.tf
+++ b/terraform/aks/newrelic/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "ReliBank"
+    storage_account_name = "relibankstate"
+    container_name       = "tfstate"
+    # key is set dynamically via CLI: relibank/{environment}/newrelic.tfstate
+    key = "relibank/default/newrelic.tfstate"
+  }
+}

--- a/terraform/aks/newrelic/dashboards/README.md
+++ b/terraform/aks/newrelic/dashboards/README.md
@@ -1,0 +1,11 @@
+# Dashboards
+
+# TMM: Drop dashboard JSON templates here as `<name>.json.tftpl` and wire each one up with a `newrelic_one_dashboard_json` resource in `../nr_dashboards.tf` using `templatefile("${path.module}/dashboards/<name>.json.tftpl", { ... })`. Demogorgon's `applications/microservices-demo/terraform/newrelic/dashboards/` is the reference layout.
+
+Template-variable conventions used by the existing placeholder:
+
+- `${app_name}` — NR display root, e.g. `ReliBank (Sandbox)`
+- `${account_id}` — numeric NR account ID (pass via `tonumber(var.new_relic_account_id)`)
+- `${support_service_guid}` — APM entity GUID resolved via `data.newrelic_entity.support_service` in `../nr_entities.tf`
+
+Add new template vars as needed — the `templatefile(...)` call in `../nr_dashboards.tf` controls the var set passed in.

--- a/terraform/aks/newrelic/dashboards/placeholder.json.tftpl
+++ b/terraform/aks/newrelic/dashboards/placeholder.json.tftpl
@@ -1,0 +1,30 @@
+{
+  "name": "${app_name} - Placeholder Dashboard",
+  "description": "Placeholder dashboard created by the ReliBank deployer's NR entities module.",
+  "permissions": "PUBLIC_READ_WRITE",
+  "pages": [
+    {
+      "name": "Overview",
+      "widgets": [
+        {
+          "title": "Support Service - Throughput",
+          "layout": {
+            "column": 1,
+            "row": 1,
+            "width": 12,
+            "height": 3
+          },
+          "visualization": { "id": "viz.line" },
+          "rawConfiguration": {
+            "nrqlQueries": [
+              {
+                "accountId": ${account_id},
+                "query": "FROM Metric SELECT rate(count(apm.service.transaction.duration), 1 minute) WHERE entityGuid = '${support_service_guid}' TIMESERIES"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/terraform/aks/newrelic/main.tf
+++ b/terraform/aks/newrelic/main.tf
@@ -1,0 +1,67 @@
+# New Relic entity management for ReliBank
+#
+# Mirrors demogorgon's `applications/microservices-demo/terraform/newrelic/newrelic/` pattern:
+# one file per NR entity type, NerdGraph CRUD via the newrelic/newrelic provider, env-scoped state.
+#
+# This module is the third layer of the ReliBank deployer:
+#   infra (relibank-infra.yml) -> app (deploy-relibank.yml) -> new relic (relibank-newrelic.yml)
+#
+# Entity data sources (nr_entities.tf) resolve real APM/Browser entities by name, which means
+# this module's `terraform apply` requires that the app tier has been deployed at least once
+# and services are reporting to NR. See docs/deployer/runbook.md for the ordering.
+#
+# The module also installs the cluster-side NR observability stack (nri-bundle + nr-ebpf-agent)
+# via helm — see nr_infra_agent.tf. The `newrelic` namespace itself is created by the infra
+# tier (terraform/aks/infra/main.tf) and merely referenced here.
+
+terraform {
+  required_providers {
+    newrelic = {
+      source  = "newrelic/newrelic"
+      version = "~> 3.61"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "2.36.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "newrelic" {
+  account_id = var.new_relic_account_id
+  api_key    = var.new_relic_user_api_key
+  region     = var.new_relic_region # Valid regions: US, EU
+}
+
+provider "azurerm" {
+  features {}
+}
+
+data "azurerm_kubernetes_cluster" "cluster" {
+  name                = var.aks_cluster_name
+  resource_group_name = var.aks_resource_group
+}
+
+provider "kubernetes" {
+  host                   = data.azurerm_kubernetes_cluster.cluster.kube_config[0].host
+  client_certificate     = base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config[0].client_certificate)
+  client_key             = base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config[0].client_key)
+  cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config[0].cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.azurerm_kubernetes_cluster.cluster.kube_config[0].host
+    client_certificate     = base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config[0].client_certificate)
+    client_key             = base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config[0].client_key)
+    cluster_ca_certificate = base64decode(data.azurerm_kubernetes_cluster.cluster.kube_config[0].cluster_ca_certificate)
+  }
+}

--- a/terraform/aks/newrelic/nr_alerts.tf
+++ b/terraform/aks/newrelic/nr_alerts.tf
@@ -1,0 +1,77 @@
+# TMM: Replace these placeholder alert policy / condition / destination / channel / workflow
+# with real definitions. The chain below is end-to-end wired so apply succeeds.
+
+resource "newrelic_alert_policy" "placeholder" {
+  name                = "${var.app_name} - Placeholder Policy"
+  incident_preference = "PER_CONDITION"
+  account_id          = var.new_relic_account_id
+}
+
+resource "newrelic_nrql_alert_condition" "placeholder_support_service_error_rate" {
+  account_id                   = var.new_relic_account_id
+  policy_id                    = newrelic_alert_policy.placeholder.id
+  type                         = "static"
+  name                         = "${var.app_name} - Placeholder Support Service Error Rate"
+  enabled                      = true
+  violation_time_limit_seconds = 10800
+
+  nrql {
+    query           = "FROM Metric SELECT (count(apm.service.error.count) / count(apm.service.transaction.duration)) * 100 WHERE entityGuid = '${data.newrelic_entity.support_service.guid}'"
+    data_account_id = var.new_relic_account_id
+  }
+
+  critical {
+    operator              = "above"
+    threshold             = 5
+    threshold_duration    = 300
+    threshold_occurrences = "all"
+  }
+}
+
+resource "newrelic_notification_destination" "placeholder_email" {
+  account_id = var.new_relic_account_id
+  name       = "${var.app_name} - Placeholder Email Destination"
+  type       = "EMAIL"
+
+  property {
+    key   = "email"
+    value = "relibank-placeholder@example.com"
+  }
+}
+
+resource "newrelic_notification_channel" "placeholder_email_template" {
+  account_id     = var.new_relic_account_id
+  name           = "${var.app_name} - Placeholder Email Template"
+  type           = "EMAIL"
+  destination_id = newrelic_notification_destination.placeholder_email.id
+  product        = "IINT"
+
+  property {
+    key   = "subject"
+    value = "{{ issueTitle }}"
+  }
+}
+
+resource "newrelic_workflow" "placeholder_workflow" {
+  account_id            = var.new_relic_account_id
+  name                  = "${var.app_name} - Placeholder Workflow"
+  enabled               = true
+  muting_rules_handling = "DONT_NOTIFY_FULLY_MUTED_ISSUES"
+
+  issues_filter {
+    name = "policy_filter"
+    type = "FILTER"
+
+    predicate {
+      attribute = "labels.policyIds"
+      operator  = "EXACTLY_MATCHES"
+      values    = ["${newrelic_alert_policy.placeholder.id}"]
+    }
+  }
+
+  destination {
+    channel_id              = newrelic_notification_channel.placeholder_email_template.id
+    notification_triggers   = ["ACTIVATED", "ACKNOWLEDGED", "CLOSED"]
+    update_original_message = true
+  }
+}

--- a/terraform/aks/newrelic/nr_dashboards.tf
+++ b/terraform/aks/newrelic/nr_dashboards.tf
@@ -1,0 +1,10 @@
+# TMM: Add new `.json.tftpl` files under `./dashboards/` and one matching
+# `newrelic_one_dashboard_json` resource per dashboard.
+
+resource "newrelic_one_dashboard_json" "placeholder" {
+  json = templatefile("${path.module}/dashboards/placeholder.json.tftpl", {
+    app_name             = var.app_name
+    account_id           = tonumber(var.new_relic_account_id)
+    support_service_guid = data.newrelic_entity.support_service.guid
+  })
+}

--- a/terraform/aks/newrelic/nr_entities.tf
+++ b/terraform/aks/newrelic/nr_entities.tf
@@ -1,0 +1,11 @@
+# TMM: Add data sources for the other 9 APM services (accounts, auth, transaction, bill-pay,
+# notifications, scheduler, risk-assessment, scenario-runner, frontend) and the Browser app.
+# APM entities resolve at plan time by name `${var.app_name} - <Service>` — requires the app
+# tier to be deployed and services reporting before apply.
+
+data "newrelic_entity" "support_service" {
+  name       = "${var.app_name} - Support Service"
+  domain     = "APM"
+  type       = "APPLICATION"
+  account_id = var.new_relic_account_id
+}

--- a/terraform/aks/newrelic/nr_entity_tags.tf
+++ b/terraform/aks/newrelic/nr_entity_tags.tf
@@ -1,0 +1,16 @@
+# TMM: Replace this placeholder tag assignment with real team / owner / tier tags. Demogorgon's
+# nr_entity_tags.tf iterates with `count` to tag every workload — pattern to extend.
+
+resource "newrelic_entity_tags" "placeholder_workload_team" {
+  guid = newrelic_workload.placeholder.guid
+
+  tag {
+    key    = "team"
+    values = ["relibank"]
+  }
+
+  tag {
+    key    = "environment"
+    values = [var.demo_environment]
+  }
+}

--- a/terraform/aks/newrelic/nr_infra_agent.tf
+++ b/terraform/aks/newrelic/nr_infra_agent.tf
@@ -1,0 +1,79 @@
+# Cluster-side NR observability stack — installs:
+#   1. nri-bundle helm chart with infrastructure, kube-state-metrics, kubeEvents, logging,
+#      and prometheus integrations enabled.
+#   2. nr-ebpf-agent helm chart for service-level Prometheus-style workload metrics.
+# Mirrors demogorgon's eks_newrelic module. License key is created as a kubernetes_secret
+# and passed to nri-bundle via customSecretName/customSecretLicenseKey to keep the license
+# out of helm release values stored on the cluster.
+#
+# The `newrelic` namespace itself is created by the infra tier
+# (terraform/aks/infra/main.tf, kubernetes_namespace_v1.newrelic). This module just installs
+# into it.
+
+locals {
+  newrelic_namespace                        = "newrelic"
+  new_relic_license_key_k8s_secret_key_name = "license_key"
+}
+
+resource "kubernetes_secret_v1" "newrelic_license" {
+  metadata {
+    name      = "newrelic-license"
+    namespace = local.newrelic_namespace
+  }
+
+  data = {
+    (local.new_relic_license_key_k8s_secret_key_name) = var.new_relic_license_key
+  }
+
+  type = "Opaque"
+}
+
+resource "helm_release" "nri_bundle" {
+  name       = "newrelic-bundle"
+  namespace  = local.newrelic_namespace
+  repository = "https://helm-charts.newrelic.com"
+  chart      = "nri-bundle"
+  wait       = true
+  timeout    = 800
+
+  values = [
+    yamlencode({
+      global = {
+        cluster                = var.aks_cluster_name
+        customSecretName       = kubernetes_secret_v1.newrelic_license.metadata[0].name
+        customSecretLicenseKey = local.new_relic_license_key_k8s_secret_key_name
+        lowDataMode            = true
+      }
+      newrelic-infrastructure = {
+        privileged = true
+      }
+      ksm        = { enabled = true }
+      kubeEvents = { enabled = true }
+      logging    = { enabled = true }
+      prometheus = { enabled = true }
+    })
+  ]
+}
+
+# Companion: nr-ebpf-agent — service-level Prometheus-style metrics on workloads.
+# Mirror of demogorgon's nr-ebpf-agent helm_release. Demogorgon pins to 1.1.0; we mirror.
+# Installed with chart defaults (no allDataFilters) — demogorgon's filter config drops all
+# services except authservice, which is demogorgon-specific. TMM can tune later if needed.
+resource "helm_release" "nr_ebpf_agent" {
+  name       = "nr-ebpf-agent"
+  namespace  = local.newrelic_namespace
+  repository = "https://helm-charts.newrelic.com"
+  chart      = "nr-ebpf-agent"
+  version    = "1.1.0"
+
+  values = [
+    yamlencode({
+      global = {
+        licenseKey = var.new_relic_license_key
+        cluster    = var.aks_cluster_name
+      }
+    })
+  ]
+
+  depends_on = [helm_release.nri_bundle]
+}

--- a/terraform/aks/newrelic/nr_service_levels.tf
+++ b/terraform/aks/newrelic/nr_service_levels.tf
@@ -1,0 +1,33 @@
+# TMM: Replace this placeholder SLI with real ones. Pattern is latency + success per service;
+# demogorgon's nr_service_levels.tf is the reference for the full set.
+
+resource "newrelic_service_level" "placeholder_support_service_latency" {
+  guid        = data.newrelic_entity.support_service.guid
+  name        = "${data.newrelic_entity.support_service.name} - Latency"
+  description = "Proportion of support-service requests served faster than 400ms."
+
+  events {
+    account_id = var.new_relic_account_id
+
+    valid_events {
+      from  = "Transaction"
+      where = "entityGuid = '${data.newrelic_entity.support_service.guid}' AND (transactionType = 'Web')"
+    }
+
+    good_events {
+      from  = "Transaction"
+      where = "entityGuid = '${data.newrelic_entity.support_service.guid}' AND (transactionType = 'Web') AND duration < 0.4"
+    }
+  }
+
+  objective {
+    target = 95
+
+    time_window {
+      rolling {
+        count = 7
+        unit  = "DAY"
+      }
+    }
+  }
+}

--- a/terraform/aks/newrelic/nr_synthetics.tf
+++ b/terraform/aks/newrelic/nr_synthetics.tf
@@ -1,0 +1,31 @@
+# TMM: Replace these placeholder ping + script monitors with real coverage (status pages,
+# checkout flow, error scenarios, etc.). Script bodies live under `./scripts/` as `.tftpl`
+# files referenced via `templatefile(...)`. Demogorgon's nr_synthetics.tf is the reference.
+
+resource "newrelic_synthetics_monitor" "placeholder_ping" {
+  status                    = "ENABLED"
+  name                      = "${var.app_name} - Placeholder Ping"
+  period                    = "EVERY_5_MINUTES"
+  uri                       = "https://${var.demo_environment}.relibankdemo.com/"
+  type                      = "SIMPLE"
+  locations_public          = ["US_WEST_2"]
+  runtime_type              = "NODE_API"
+  runtime_type_version      = "16.10"
+  treat_redirect_as_failure = false
+  bypass_head_request       = true
+  verify_ssl                = true
+}
+
+resource "newrelic_synthetics_script_monitor" "placeholder_script" {
+  status               = "ENABLED"
+  name                 = "${var.app_name} - Placeholder Script Monitor"
+  type                 = "SCRIPT_API"
+  period               = "EVERY_30_MINUTES"
+  locations_public     = ["US_WEST_2"]
+  runtime_type         = "NODE_API"
+  runtime_type_version = "16.10"
+
+  script = templatefile("${path.module}/scripts/placeholder.tftpl", {
+    demo_environment = var.demo_environment
+  })
+}

--- a/terraform/aks/newrelic/nr_workloads.tf
+++ b/terraform/aks/newrelic/nr_workloads.tf
@@ -1,0 +1,11 @@
+# TMM: Replace this placeholder workload with real ones grouped by team / ownership / function.
+# For multi-team, demogorgon's nr_workloads.tf iterates with `count` over a `locals.nr_team_list`.
+
+resource "newrelic_workload" "placeholder" {
+  name       = "${var.app_name} - Placeholder Workload"
+  account_id = var.new_relic_account_id
+
+  entity_guids = [
+    data.newrelic_entity.support_service.guid,
+  ]
+}

--- a/terraform/aks/newrelic/outputs.tf
+++ b/terraform/aks/newrelic/outputs.tf
@@ -1,0 +1,4 @@
+# Intentionally empty.
+#
+# Mirrors demogorgon's module — no outputs are exposed for downstream consumption.
+# Entities are referenced by other tooling via NR UI / NerdGraph, not via TF remote_state.

--- a/terraform/aks/newrelic/scripts/README.md
+++ b/terraform/aks/newrelic/scripts/README.md
@@ -1,0 +1,9 @@
+# Synthetics scripts
+
+# TMM: Drop synthetic-monitor script templates here as `<name>.tftpl` and wire each one up with a `newrelic_synthetics_script_monitor` resource in `../nr_synthetics.tf` using `templatefile("${path.module}/scripts/<name>.tftpl", { ... })`. Demogorgon's `applications/microservices-demo/terraform/newrelic/scripts/` is the reference layout.
+
+Template-variable conventions used by the existing placeholder:
+
+- `${demo_environment}` — env name (sandbox, staging, prod, analysts); used to build the target URL
+
+Add new template vars as needed — the `templatefile(...)` call in `../nr_synthetics.tf` controls the var set passed in. SIMPLE / ping monitors don't take a script body, so they stay inline in `nr_synthetics.tf` and don't belong in this directory.

--- a/terraform/aks/newrelic/scripts/placeholder.tftpl
+++ b/terraform/aks/newrelic/scripts/placeholder.tftpl
@@ -1,0 +1,7 @@
+// TMM: replace this placeholder script with a real synthetic check.
+var assert = require('assert');
+$http.get('https://${demo_environment}.relibankdemo.com/',
+  function (err, response, body) {
+    assert.equal(response.statusCode, 200, 'Expected HTTP 200');
+  }
+);

--- a/terraform/aks/newrelic/variables.tf
+++ b/terraform/aks/newrelic/variables.tf
@@ -1,0 +1,46 @@
+variable "new_relic_account_id" {
+  description = "New Relic account ID (numeric). Same value as NR_ACCOUNT_ID in the GH Environment."
+  type        = string
+}
+
+variable "new_relic_user_api_key" {
+  description = "New Relic user API key (NRAK-...). NerdGraph CRUD for entity management."
+  type        = string
+  sensitive   = true
+  validation {
+    condition     = can(regex("^NRAK-", var.new_relic_user_api_key))
+    error_message = "Expected a New Relic user API key with NRAK- prefix."
+  }
+}
+
+variable "new_relic_license_key" {
+  description = "New Relic license key (FFFFNRAL suffix). Kept here for parity with demogorgon's module signature; not currently consumed by any placeholder resource but useful for future agent/integration wiring."
+  type        = string
+  sensitive   = true
+}
+
+variable "new_relic_region" {
+  description = "New Relic region. Valid: US, EU."
+  type        = string
+  default     = "US"
+}
+
+variable "demo_environment" {
+  description = "Environment name (sandbox, staging, prod, analysts). Suffixes entity names so per-env entities are disambiguated in the NR UI."
+  type        = string
+}
+
+variable "app_name" {
+  description = "NR APM display root (e.g. `ReliBank (Sandbox)`). Service entities are named `{app_name} - {Service}`; placeholder entities use this as a prefix too."
+  type        = string
+}
+
+variable "aks_cluster_name" {
+  description = "AKS cluster name. Used to data-source kube credentials for the helm/kubernetes providers that install the cluster-side NR observability stack."
+  type        = string
+}
+
+variable "aks_resource_group" {
+  description = "AKS cluster resource group. Pair with aks_cluster_name."
+  type        = string
+}

--- a/tests/workflow_validation/validate_nr_workflow.py
+++ b/tests/workflow_validation/validate_nr_workflow.py
@@ -1,0 +1,308 @@
+"""
+Post-apply validation for the ReliBank NR workflow.
+
+Confirms two things after `relibank-newrelic.yml` runs `terraform apply`:
+
+  1. The entities created by the `newrelic/newrelic` provider are present in NR
+     (queryable from the API user's perspective). One test per entity type.
+  2. The cluster-side helm releases installed by the same apply (`nri-bundle`,
+     `nr-ebpf-agent`) are actually reporting telemetry — K8sClusterSample for
+     the cluster, K8sPodSample for the `newrelic` namespace.
+
+Modelled on demogorgon's test-scripts/nrql-data-validation.py: pytest file,
+NerdGraph helper, env-var precondition, hard assertions. The workflow job uses
+`continue-on-error: true` on the pytest step + a follow-up check step so per-
+test failures stay visible in the report but the overall job still fails.
+
+Run by `.github/workflows/relibank-newrelic.yml` (job `relibank-newrelic-validate`).
+"""
+
+import os
+
+import pytest
+import requests
+
+API_KEY = os.environ.get("NR_USER_API_KEY")
+ACCOUNT_ID = os.environ.get("NR_ACCOUNT_ID")
+APP_NAME = os.environ.get("APP_NAME")
+AKS_CLUSTER_NAME = os.environ.get("AKS_CLUSTER_NAME")
+
+NERDGRAPH_ENDPOINT = "https://api.newrelic.com/graphql"
+
+if not API_KEY:
+    pytest.skip("NR_USER_API_KEY not set", allow_module_level=True)
+if not ACCOUNT_ID:
+    pytest.skip("NR_ACCOUNT_ID not set", allow_module_level=True)
+if not APP_NAME:
+    pytest.skip("APP_NAME not set", allow_module_level=True)
+if not AKS_CLUSTER_NAME:
+    pytest.skip("AKS_CLUSTER_NAME not set", allow_module_level=True)
+
+
+def query_nerdgraph(graphql):
+    response = requests.post(
+        NERDGRAPH_ENDPOINT,
+        headers={"API-Key": API_KEY, "Content-Type": "application/json"},
+        json={"query": graphql},
+        timeout=30,
+    )
+    response.raise_for_status()
+    data = response.json()
+    if "errors" in data:
+        raise AssertionError(f"GraphQL errors: {data['errors']}")
+    return data
+
+
+def assert_entity_exists(name, entity_type):
+    """Query NerdGraph entitySearch for `name` + `type`, assert at least one match."""
+    graphql = f"""
+    {{
+      actor {{
+        entitySearch(query: "name = '{name}' AND type = '{entity_type}'") {{
+          results {{
+            entities {{ guid name type }}
+          }}
+        }}
+      }}
+    }}
+    """
+    data = query_nerdgraph(graphql)
+    entities = (
+        data.get("data", {})
+        .get("actor", {})
+        .get("entitySearch", {})
+        .get("results", {})
+        .get("entities", [])
+    )
+    matches = [e for e in entities if e.get("name") == name]
+    assert matches, f"No {entity_type} entity found with name '{name}'"
+    print(f"  OK {entity_type}: '{name}' (guid={matches[0]['guid']})")
+
+
+def run_nrql(nrql):
+    graphql = f"""
+    {{
+      actor {{
+        account(id: {ACCOUNT_ID}) {{
+          nrql(query: "{nrql}") {{ results }}
+        }}
+      }}
+    }}
+    """
+    data = query_nerdgraph(graphql)
+    return (
+        data.get("data", {})
+        .get("actor", {})
+        .get("account", {})
+        .get("nrql", {})
+        .get("results", [])
+    )
+
+
+# ---------------------------------------------------------------------------
+# Group A: entity existence
+# ---------------------------------------------------------------------------
+
+def test_dashboard_entity_exists():
+    """`newrelic_one_dashboard_json.placeholder` — Dashboard, queried via entitySearch."""
+    assert_entity_exists(f"{APP_NAME} - Placeholder Dashboard", "DASHBOARD")
+
+
+def test_workload_entity_exists():
+    """`newrelic_workload.placeholder` — Workload, queried via entitySearch."""
+    assert_entity_exists(f"{APP_NAME} - Placeholder Workload", "WORKLOAD")
+
+
+def test_synthetics_ping_monitor_exists():
+    """`newrelic_synthetics_monitor.placeholder_ping` — Monitor, queried via entitySearch."""
+    assert_entity_exists(f"{APP_NAME} - Placeholder Ping", "MONITOR")
+
+
+def test_synthetics_script_monitor_exists():
+    """`newrelic_synthetics_script_monitor.placeholder_script` — Monitor, queried via entitySearch."""
+    assert_entity_exists(f"{APP_NAME} - Placeholder Script Monitor", "MONITOR")
+
+
+def test_alert_policy_exists():
+    """`newrelic_alert_policy.placeholder` — queried via alerts.policiesSearch."""
+    name = f"{APP_NAME} - Placeholder Policy"
+    graphql = f"""
+    {{
+      actor {{
+        account(id: {ACCOUNT_ID}) {{
+          alerts {{
+            policiesSearch(searchCriteria: {{ name: "{name}" }}) {{
+              policies {{ id name }}
+            }}
+          }}
+        }}
+      }}
+    }}
+    """
+    data = query_nerdgraph(graphql)
+    policies = (
+        data.get("data", {})
+        .get("actor", {})
+        .get("account", {})
+        .get("alerts", {})
+        .get("policiesSearch", {})
+        .get("policies", [])
+    )
+    matches = [p for p in policies if p.get("name") == name]
+    assert matches, f"No alert policy found with name '{name}'"
+    print(f"  OK alert policy: '{name}' (id={matches[0]['id']})")
+
+
+def test_nrql_alert_condition_exists():
+    """`newrelic_nrql_alert_condition.placeholder_support_service_error_rate` — queried via alerts.nrqlConditionsSearch."""
+    name = f"{APP_NAME} - Placeholder Support Service Error Rate"
+    graphql = f"""
+    {{
+      actor {{
+        account(id: {ACCOUNT_ID}) {{
+          alerts {{
+            nrqlConditionsSearch(searchCriteria: {{ name: "{name}" }}) {{
+              nrqlConditions {{ id name }}
+            }}
+          }}
+        }}
+      }}
+    }}
+    """
+    data = query_nerdgraph(graphql)
+    conditions = (
+        data.get("data", {})
+        .get("actor", {})
+        .get("account", {})
+        .get("alerts", {})
+        .get("nrqlConditionsSearch", {})
+        .get("nrqlConditions", [])
+    )
+    matches = [c for c in conditions if c.get("name") == name]
+    assert matches, f"No NRQL alert condition found with name '{name}'"
+    print(f"  OK NRQL condition: '{name}' (id={matches[0]['id']})")
+
+
+def test_notification_destination_exists():
+    """`newrelic_notification_destination.placeholder_email` — queried via aiNotifications.destinations."""
+    name = f"{APP_NAME} - Placeholder Email Destination"
+    graphql = f"""
+    {{
+      actor {{
+        account(id: {ACCOUNT_ID}) {{
+          aiNotifications {{
+            destinations(filters: {{ name: "{name}" }}) {{
+              entities {{ id name }}
+            }}
+          }}
+        }}
+      }}
+    }}
+    """
+    data = query_nerdgraph(graphql)
+    entities = (
+        data.get("data", {})
+        .get("actor", {})
+        .get("account", {})
+        .get("aiNotifications", {})
+        .get("destinations", {})
+        .get("entities", [])
+    )
+    matches = [e for e in entities if e.get("name") == name]
+    assert matches, f"No notification destination found with name '{name}'"
+    print(f"  OK destination: '{name}' (id={matches[0]['id']})")
+
+
+def test_notification_channel_exists():
+    """`newrelic_notification_channel.placeholder_email_template` — queried via aiNotifications.channels."""
+    name = f"{APP_NAME} - Placeholder Email Template"
+    graphql = f"""
+    {{
+      actor {{
+        account(id: {ACCOUNT_ID}) {{
+          aiNotifications {{
+            channels(filters: {{ name: "{name}" }}) {{
+              entities {{ id name }}
+            }}
+          }}
+        }}
+      }}
+    }}
+    """
+    data = query_nerdgraph(graphql)
+    entities = (
+        data.get("data", {})
+        .get("actor", {})
+        .get("account", {})
+        .get("aiNotifications", {})
+        .get("channels", {})
+        .get("entities", [])
+    )
+    matches = [e for e in entities if e.get("name") == name]
+    assert matches, f"No notification channel found with name '{name}'"
+    print(f"  OK channel: '{name}' (id={matches[0]['id']})")
+
+
+def test_workflow_exists():
+    """`newrelic_workflow.placeholder_workflow` — queried via aiWorkflows.workflows."""
+    name = f"{APP_NAME} - Placeholder Workflow"
+    graphql = f"""
+    {{
+      actor {{
+        account(id: {ACCOUNT_ID}) {{
+          aiWorkflows {{
+            workflows(filters: {{ name: "{name}" }}) {{
+              entities {{ id name }}
+            }}
+          }}
+        }}
+      }}
+    }}
+    """
+    data = query_nerdgraph(graphql)
+    entities = (
+        data.get("data", {})
+        .get("actor", {})
+        .get("account", {})
+        .get("aiWorkflows", {})
+        .get("workflows", {})
+        .get("entities", [])
+    )
+    matches = [e for e in entities if e.get("name") == name]
+    assert matches, f"No workflow found with name '{name}'"
+    print(f"  OK workflow: '{name}' (id={matches[0]['id']})")
+
+
+# ---------------------------------------------------------------------------
+# Group B: cluster telemetry from helm install
+# ---------------------------------------------------------------------------
+
+def test_cluster_sample_reporting():
+    """nri-bundle's kube-state-metrics integration reports K8sClusterSample."""
+    nrql = (
+        f"SELECT count(*) AS c FROM K8sClusterSample "
+        f"WHERE clusterName = '{AKS_CLUSTER_NAME}' SINCE 10 minutes ago LIMIT 1"
+    )
+    results = run_nrql(nrql)
+    count = (results[0].get("c") if results else 0) or 0
+    assert count > 0, (
+        f"No K8sClusterSample for clusterName='{AKS_CLUSTER_NAME}' in last 10 minutes. "
+        "Is nri-bundle running and reporting?"
+    )
+    print(f"  OK K8sClusterSample count={count} for clusterName='{AKS_CLUSTER_NAME}'")
+
+
+def test_newrelic_namespace_pods_reporting():
+    """nri-bundle agent pods themselves visible in K8sPodSample (end-to-end sanity)."""
+    nrql = (
+        f"SELECT count(*) AS c FROM K8sPodSample "
+        f"WHERE clusterName = '{AKS_CLUSTER_NAME}' AND namespace = 'newrelic' "
+        f"SINCE 10 minutes ago LIMIT 1"
+    )
+    results = run_nrql(nrql)
+    count = (results[0].get("c") if results else 0) or 0
+    assert count > 0, (
+        f"No K8sPodSample for namespace='newrelic' on cluster='{AKS_CLUSTER_NAME}' "
+        "in last 10 minutes. The NR agent pods exist but are not being scraped."
+    )
+    print(f"  OK K8sPodSample count={count} for namespace='newrelic'")


### PR DESCRIPTION
```
feat: add terraform module for relibank NR entities + deployer docs
feat: externalize NR dashboard JSON + synthetics script bodies to .tftpl files
feat: install nri-bundle + nr-ebpf-agent helm charts in NR workflow
feat: add post-apply NR entity + cluster telemetry validation job
docs: add TMM-facing README for terraform/aks/newrelic
docs: drop placeholder paragraph from NR module README
```

🚀 Pull Request
========================

🎯 PR Type
----------
-   [x] **Feature:** Adds new functionality or user-facing change.
-   [ ] **Bug Fix:** Solves a defect or incorrect behavior.
-   [ ] **Refactor:** Improves code structure/readability without changing external behavior.
-   [x] **Documentation:** Updates to README, Wiki, or internal docs.
-   [ ] **Chore:** Non-code changes (e.g., CI configuration, dependency bumps).

1\. Issue Tracking & Reference
------------------------------
-   **Ticket Number(s):** NR-562935
-   **Ticket Link(s):** https://new-relic.atlassian.net/browse/NR-562935

2\. Summary of Changes
----------------------
Adds a dedicated New Relic terraform module to the ReliBank deployer, installs the cluster-side NR helm agents (`nri-bundle`, `nr-ebpf-agent`), and adds a post-apply validation job that asserts every NR entity and cluster telemetry stream is present in NR before the workflow exits success.
-   **Expected Outcome:** Triggering `ReliBank NR` with `action_type=deploy` against any environment provisions the full placeholder NR entity set (dashboard, alert policy, NRQL condition, notification destination/channel, workflow, workload, synthetics ping + script monitors, SLI, entity tags) plus the helm-installed cluster agents, then hard-gates the workflow on NerdGraph + NRQL validation that confirms each shows up in New Relic.

### Detailed Change Log & Justification
-   **Change 1:** Added `terraform/aks/newrelic/` module with one `nr_*.tf` file per entity type, externalized dashboard JSON and synthetics script bodies into `dashboards/*.json.tftpl` and `scripts/*.tftpl`, and added `nr_infra_agent.tf` to install `nri-bundle` + `nr-ebpf-agent` via helm.
    -   **Justification:** Establishes the entity-management surface area for TMM and gives ReliBank cluster + APM observability parity with demogorgon.
-   **Change 2:** Added the `relibank-newrelic-validate` job to `.github/workflows/relibank-newrelic.yml`. The job waits 120s, runs `tests/workflow_validation/validate_nr_workflow.py` with `continue-on-error: true`, and a follow-up step fails the job if the pytest outcome wasn't success.
    -   **Justification:** Mirrors demogorgon's `post-deployment-validation.yml` apply-then-check-outcome pattern so per-entity failures show in the pytest report while the job still hard-gates the workflow.
-   **Change 3:** Added `tests/workflow_validation/validate_nr_workflow.py` — pytest file with 9 entity-existence tests (NerdGraph `entitySearch`, `alerts.policiesSearch`, `alerts.nrqlConditionsSearch`, `aiNotifications.destinations`, `aiNotifications.channels`, `aiWorkflows.workflows`) and 2 cluster-telemetry tests (`K8sClusterSample`, `K8sPodSample` on the `newrelic` namespace).
    -   **Justification:** Different NR entity types live under different NerdGraph subgraphs, so each test picks the right query shape. The K8s telemetry checks confirm the helm install is reporting end-to-end, not just installed.
-   **Change 4:** Added `terraform/aks/newrelic/README.md` — TMM-facing onboarding doc covering a Terraform primer, file layout, placeholder-update recipe, env-aware variable recipe, and a recipe for adding a validation test per new entity.
    -   **Justification:** TMM owns this directory but does not have prior Terraform experience; the README front-loads the concepts they actually need.
-   **Change 5:** Updated `docs/deployer/deployer_primer.md`, `docs/deployer/runbook.md`, and `docs/deployer/secrets_reference.md` to document the new validate job, the 120s propagation wait, and the env vars/secrets it consumes.
    -   **Justification:** Keeps the operational docs aligned with the new third NR job in the workflow.

3\. Testing
-----------

### Testing Strategy
-   **Environment Used:** Sandbox
-   **Production Safety Assessment:** The change is gated per environment (workflow input `environment`) and only runs when manually dispatched. The validate job uses `continue-on-error: true` on the pytest step so individual entity-check failures are surfaced as readable pytest output rather than opaque step failures, then hard-gates on the outcome. The TF module operates against an isolated NR workspace per env and the helm agents are namespaced to `newrelic`.
-   **What areas were NOT tested and why?** Service-level (SLI) coverage is not exercised by `validate_nr_workflow.py` — it needs a parent-workload SLI list query that's out of scope for the placeholder pass. Destroy-side validation is intentionally skipped because querying for entity absence is ambiguous due to deletion propagation lag.

### Coverage Details

| Scenario      | Details                                                                    | Results                           |
| ------------- | -------------------------------------------------------------------------- | --------------------------------- |
| Happy Path    | Trigger `ReliBank NR` with `action_type=deploy environment=sandbox`. Expect deploy job to apply the module, validate job to wait 120s then assert every entity + cluster telemetry stream is present. | Pass — all 11 validation tests reported pass; validate job exited 0. |
| Edge Case 1   | Full destroy + redeploy: trigger `action_type=destroy`, confirm clean tear-down, then re-trigger `action_type=deploy` on a fresh state and watch validation re-converge. | Pass — destroy returned 0; redeploy + validation converged on the second run. |
| Edge Case 2   | Re-trigger the validate job in isolation against an already-deployed env to confirm it's idempotent and doesn't depend on a fresh apply. | Pass — validate job re-ran green against the already-deployed sandbox env. |

4\. Evidence
------------
-   **Screenshots/Gifs:** 
<img width="1746" height="763" alt="image" src="https://github.com/user-attachments/assets/cd0d18f5-24d8-4f77-b222-ad44182d2036" />

-   **Console/Log Output Snippets:** `relibank-newrelic-validate` job log from the sandbox run shows each `test_*` function passing with the pytest `-v` line-per-test output.
-   **Test Report Links:** GitHub Actions run for `feat/deployer-new-relic-step` against `environment=sandbox`.

5\. Review and Merge Checklist
------------------------------
-   [x] All blocking review comments from the latest round are **resolved**.
-   [x] This branch has been rebased against the `main` branch and all **merge conflicts are resolved**.
-   [x] The code includes sufficient comments, particularly in complex or non-obvious areas.
-   [x] The code adheres to project **coding standards** (linting, style guides, best practices).
-   [x] Relevant documentation and runbooks have been updated, if necessary.
-   [x] My changes generate no new warnings or errors.
-   [x] My commits are squashed into a single, descriptive commit.
-   [x] My test results are uploaded as a text file, and new tests were created where required.
