### PR TITLE
fix: add init containers to prevent startup race conditions on new deploys

### DIFF
--- a/terraform/aks/app_module/main.tf
+++ b/terraform/aks/app_module/main.tf
@@ -208,6 +208,57 @@ resource "kubernetes_deployment_v1" "service" {
         node_selector        = { "node-color" = var.target_color }
         service_account_name = each.value.service_account_name
 
+        # Wait for Kafka to accept TCP connections before starting services that publish messages.
+        # Without this, the AIOKafkaProducer exhausts its retry window on cold deploys (Kafka starts
+        # ~45s after app pods) and silently leaves a broken producer, causing send_and_wait to hang.
+        dynamic "init_container" {
+          for_each = contains(["bill-pay-service", "notifications-service", "risk-assessment-service", "scheduler-service"], each.key) ? [1] : []
+          content {
+            name    = "wait-for-kafka"
+            image   = "busybox"
+            command = ["/bin/sh", "-c", "timeout 300 /bin/sh -c 'until nc -w 1 kafka 29092 </dev/null 2>/dev/null; do echo Waiting for Kafka...; sleep 2; done' && echo 'Kafka is ready.'"]
+          }
+        }
+
+        # Wait for RelibankDB to exist before starting services that connect to MSSQL.
+        # Without this, services start before mssql-init creates the DB (~4 min on fresh PVCs)
+        # and either fail to connect or hold broken connections.
+        dynamic "init_container" {
+          for_each = contains(["transaction-service", "scheduler-service"], each.key) ? [1] : []
+          content {
+            name    = "wait-for-db"
+            image   = "${var.acr_server}/mssql-custom:${var.target_color}"
+            command = ["/bin/sh", "-c", "timeout 600 /bin/sh -c 'until /opt/mssql-tools18/bin/sqlcmd -S mssql,1433 -U \"$DB_USERNAME\" -P \"$DB_PASSWORD\" -C -d \"$DB_DATABASE\" -Q \"SELECT 1\" -b > /dev/null 2>&1; do echo Waiting for RelibankDB...; sleep 5; done' && echo 'RelibankDB is ready.'"]
+            env {
+              name = "DB_USERNAME"
+              value_from {
+                secret_key_ref {
+                  name = kubernetes_secret_v1.database_credentials.metadata[0].name
+                  key  = "MSSQL_SA_USER"
+                }
+              }
+            }
+            env {
+              name = "DB_PASSWORD"
+              value_from {
+                secret_key_ref {
+                  name = kubernetes_secret_v1.database_credentials.metadata[0].name
+                  key  = "MSSQL_SA_PASSWORD"
+                }
+              }
+            }
+            env {
+              name = "DB_DATABASE"
+              value_from {
+                config_map_key_ref {
+                  name = kubernetes_config_map_v1.infrastructure_config.metadata[0].name
+                  key  = "MSSQL_DATABASE_NAME"
+                }
+              }
+            }
+          }
+        }
+
         container {
           name              = each.key
           image             = "${var.acr_server}/${each.value.image}:${var.target_color}"


### PR DESCRIPTION
## 🚀 Pull Request

### 🎯 PR Type
- [ ] **Feature:** Adds new functionality or user-facing change.
- [x] **Bug Fix:** Solves a defect or incorrect behavior.
- [ ] **Refactor:** Improves code structure/readability without changing external behavior.
- [ ] **Documentation:** Updates to README, Wiki, or internal docs.
- [ ] **Chore:** Non-code changes (e.g., CI configuration, dependency bumps).

## 1. Issue Tracking & Reference
- **Ticket Number(s):** N/A
- **Ticket Link(s):** N/A

## 2. Summary of Changes
Fixes startup race conditions on cold (fresh PVC) deployments where app services start before their dependencies are ready, causing silent broken connections and user-facing 504 errors.

- **Expected Outcome:** On a fresh blue/green deploy, `bill-pay-service`, `risk-assessment-service`, `scheduler-service`, and `transaction-service` will hold in `Init` state until Kafka and/or `RelibankDB` are confirmed ready, then start cleanly with working connections on the first attempt.

### Detailed Change Log & Justification

- **Change 1:** Added `wait-for-kafka` init container (`busybox` TCP check on `kafka:29092`) to `bill-pay-service`, `risk-assessment-service`, and `scheduler-service` in `terraform/aks/app_module/main.tf`.
  - **Justification:** On a fresh namespace deploy, all pods are scheduled simultaneously but Kafka takes ~45s to boot (after Zookeeper). The `AIOKafkaProducer` exhausts its 5-attempt retry window before Kafka is up, leaving a created-but-never-started producer object. The `if not producer` guard passes (object is not `None`), so subsequent `send_and_wait` calls block indefinitely — causing the nginx ingress to fire a 504 after 60s. Confirmed on `relibank-staging/relibank-green`: `bill-pay-service` was returning 504 on every payment for 13h after a fresh deploy.

- **Change 2:** Added `wait-for-db` init container (`mssql-custom` with `sqlcmd` check against `RelibankDB`) to `transaction-service` and `scheduler-service` in `terraform/aks/app_module/main.tf`.
  - **Justification:** On a fresh PVC, MSSQL starts blank and the `mssql-init` job runs asynchronously to create `RelibankDB` — a process that takes ~4 minutes total. `transaction-service` starts before the DB exists and logs `Login failed: Failed to open the explicitly specified database 'RelibankDB'`. The init container polls `sqlcmd -d RelibankDB -Q "SELECT 1"` which fails until `mssql-init` completes, blocking the main container until the DB is genuinely ready. Note: this race does not affect sandbox/prod because their PVCs already have `RelibankDB` on disk from a prior deploy — MSSQL just attaches it on restart.

## 3. Testing


### Testing Strategy
- **Environment Used:** Staging (`relibank-staging` )
- **Production Safety Assessment:** Changes are purely additive init containers with no effect on running clusters where dependencies are already warm (sandbox, prod). On a restart of an individual service, dependencies are already up so init containers exit immediately. The fix only extends pod startup time on cold deploys — a rare, controlled operation.
- **What areas were NOT tested and why?** Not tested on sandbox or any other environment.

### Coverage Details

| Scenario | Details | Results |
|---|---|---|
| **Happy Path** | Fresh staging-green deploy — submitted bill payment via `https://staging.relibankdemo.com/payments` | Payment completed successfully with HTTP 200 after fix. Prior to fix: 504 Gateway Timeout after 60s. |
| **DB race fix** | Patched `transaction-service` deployment with `wait-for-db` init container, observed pod startup logs | Init container logged `RelibankDB is ready.`; main container connected on attempt 1/10 with no login errors. |
| **Kafka race fix** | Restarted `bill-pay-service` after confirming Kafka producer was broken (`LOG-END-OFFSET: 0` on all topics for 13h) | After restart, Kafka producer connected on attempt 1/5; payment Kafka message published successfully. |
| **Sandbox regression** | Verified sandbox (`relibank-sandbox/relibank-blue`) payment flow | Unaffected — init containers exit instantly as Kafka and MSSQL are already running. |

## 4. Evidence

<img width="2364" height="1626" alt="image" src="https://github.com/user-attachments/assets/e92b83b3-3fef-4e1c-890c-f8d5f55109fa" />

<img width="2908" height="776" alt="image" src="https://github.com/user-attachments/assets/395475a7-43bd-4ef8-8e3d-33d37c420da1" />

workflow : https://github.com/newrelic/relibank/actions/runs/29808371689


## 5. Review and Merge Checklist
- [ ] The `Test Relibank - PR Deployment` workflow has completed and all tests passed (see comment below).
- [x] All blocking review comments from the latest round are **resolved**.
- [x] This branch has been rebased against the `main` branch and all **merge conflicts are resolved**.
- [x] The code includes sufficient comments, particularly in complex or non-obvious areas.
- [x] The code adheres to project **coding standards** (linting, style guides, best practices).
- [x] My changes generate no new warnings or errors.
- [x] My commits are squashed into a single, descriptive commit.