### PR TITLE
fix: transaction-service/accounts-service bugs and sandbox test-suite reliability

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -166,6 +166,8 @@ jobs:
           FRONTEND_SERVICE_URL: ${{ vars.BASE_URL }}
           NEW_RELIC_USER_API_KEY: ${{ secrets.NR_USER_API_KEY }}
           NEW_RELIC_ACCOUNT_ID: ${{ vars.NR_ACCOUNT_ID }}
+          APP_NAME: ${{ vars.APP_NAME }}
+          NR_BROWSER_APP_NAME: ${{ vars.NR_BROWSER_APP_NAME }}
           # Scenario-UI webpage test: direct at a color (X-Test-Env) + expected flag state,
           # threaded from the deploy so no manual sync. Empty color = active color.
           TARGET_COLOR: ${{ env.EFFECTIVE_COLOR || inputs.target_color }}

--- a/accounts_service/accounts_service.py
+++ b/accounts_service/accounts_service.py
@@ -463,6 +463,8 @@ async def get_user(email: str, request: Request):
             if not user:
                 raise HTTPException(status_code=404, detail="User not found.")
             return User(**user)
+    except HTTPException:
+        raise
     except Exception as e:
         logging.error(f"Error retrieving user: {e}")
         newrelic.agent.notice_error(attributes={
@@ -627,6 +629,8 @@ async def get_accounts(email: str, request: Request):
                             account["transaction_count"] = 0
 
             return [Account(**account) for account in all_accounts]
+    except HTTPException:
+        raise
     except Exception as e:
         logging.exception(f"Error retrieving accounts: {e}")
         newrelic.agent.notice_error(attributes={
@@ -676,6 +680,8 @@ async def get_account_type(account_id: int, request: Request):
             process_headers(dict(request.headers))
 
             raise HTTPException(status_code=404, detail="Account not found.")
+    except HTTPException:
+        raise
     except Exception as e:
         logging.error(f"Error retrieving account type: {e}")
         newrelic.agent.notice_error(attributes={
@@ -823,6 +829,10 @@ async def create_account(email: str, account: Account, request: Request):
                 'action': 'create_account'
             })
             raise HTTPException(status_code=400, detail="Invalid account data provided.")
+    except HTTPException:
+        if conn:
+            conn.rollback()
+        raise
     except Exception as e:
         if conn:
             conn.rollback()

--- a/bill_pay/bill_pay_service.py
+++ b/bill_pay/bill_pay_service.py
@@ -616,6 +616,7 @@ async def process_card_payment(payment: CardPaymentRequest, request: Request):
 
     try:
         logging.info(f"Processing card payment for bill ID: {payment.billId}, amount: ${payment.amount}")
+        risk_decline_info = None
 
         propagation_headers = get_propagation_headers(request)
 

--- a/docs/SCENARIO_AUTHORING.md
+++ b/docs/SCENARIO_AUTHORING.md
@@ -144,10 +144,15 @@ its intentional blocking semantics (don't make it async). All FastAPI services t
 Pod-kill / resource-stress scenarios are Chaos Mesh custom resources under
 `scenario_service/chaos_mesh/experiments/` (`relibank-pod-chaos-adhoc.yaml`,
 `relibank-stress-scenarios.yaml`). Add a `PodChaos`/`StressChaos` YAML with the standard
-`namespace: relibank` + `experiment-type` / `target-flow` labels; the scenario service loads them at
-startup and exposes them via `/scenario-runner/api/scenarios`, triggered by
-`POST /scenario-runner/api/trigger_chaos/{name}` (or `trigger_stress`). `flow-stress-chaos.yml`
-schedules them.
+`namespace: relibank` + `experiment-type` / `target-flow` labels — the scenario service overrides
+that `namespace` (and each selector's `namespaces` entry) at startup with the pod's actual namespace
+(via `get_current_namespace()`, reading the serviceaccount token mount), so it works unchanged
+whether the cluster is single-namespace or blue/green (`relibank-blue`/`relibank-green`). The
+scenario service loads the (overridden) experiments at startup and exposes them via
+`/scenario-runner/api/scenarios`, triggered by `POST /scenario-runner/api/trigger_chaos/{name}` (or
+`trigger_stress`). Both accept `?dry_run=true` to check the selector matches at least one live pod
+without creating any chaos-mesh resource — use it to sanity-check a new experiment's selector before
+scheduling it live. `flow-stress-chaos.yml` schedules them.
 
 ---
 

--- a/k8s/base/services/transaction-service-deployment.yaml
+++ b/k8s/base/services/transaction-service-deployment.yaml
@@ -42,6 +42,11 @@ spec:
                 configMapKeyRef:
                   key: KAFKA_BROKER
                   name: infrastructure-config
+            - name: ACCOUNTS_SERVICE_URL
+              valueFrom:
+                configMapKeyRef:
+                  key: ACCOUNTS_SERVICE_URL
+                  name: infrastructure-config
           image: transaction-service
           # livenessProbe:
           #   exec:

--- a/scenario_service/CLAUDE.md
+++ b/scenario_service/CLAUDE.md
@@ -26,16 +26,23 @@ endpoints (plus the `index.html` UI):
 - **A/B tests** (`AB_TEST_SCENARIOS`, ~line 70): LCP slowness (percentage + cohort) and DB pool
   stress — consumed by `accounts-service`. See [`accounts_service/CLAUDE.md`](../accounts_service/CLAUDE.md).
 - **Chaos Mesh experiments** (`CHAOS_EXPERIMENTS` / `STRESS_EXPERIMENTS`, loaded from
-  `chaos_mesh/experiments/*.yaml`): pod-kill, pod-failure, CPU/memory/combined stress. Triggered via
-  `POST /scenario-runner/api/trigger_chaos/{name}` and `trigger_stress/{name}`, rate-limited
-  (`CHAOS_RATE_LIMIT`, ~line 97: cooldown + max concurrent).
+  `chaos_mesh/experiments/*.yaml`): pod-kill, pod-failure, CPU/memory/combined stress. Each YAML's
+  `namespace: relibank` is overridden at startup with the pod's actual namespace (`get_current_namespace()`),
+  so experiments still target the right pods on blue/green (`relibank-blue`/`relibank-green`).
+  Triggered via `POST /scenario-runner/api/trigger_chaos/{name}` and `trigger_stress/{name}`,
+  rate-limited (`CHAOS_RATE_LIMIT`, ~line 97: cooldown + max concurrent). Both accept `?dry_run=true`
+  to report `matched_pods` for the experiment's selector without creating a chaos-mesh resource or
+  touching the rate limiter — an opt-in read that doesn't change default trigger behavior, used by
+  `tests/test_scenario_service.py::test_all_chaos_scenarios_have_matching_pods` to catch
+  selector/namespace drift in CI.
 - **db-360 load generation**: sustained MSSQL workers (velocity / blocker / contender) to populate
   Query Plan Manager. `POST /scenario-runner/api/db-360/start|stop|status`.
 
 These are toggled interactively (UI/API) and on schedules by `.github/workflows/flow-*.yml`.
 
 **Don't:** "harden" the injection logic, add safety rails that neuter scenarios, disable the chaos
-triggers, or treat the rate limiter / experiment loading as defects.
+triggers, or treat the rate limiter / experiment loading as defects. `dry_run` is opt-in and only
+reports pod counts — it must never become the default or gate the real trigger path.
 
 ---
 

--- a/scenario_service/chaos_mesh/README.md
+++ b/scenario_service/chaos_mesh/README.md
@@ -94,22 +94,23 @@ The Chaos Mesh dashboard is accessible at:
 ## 📊 Managing Experiments
 
 ```bash
-# View active scheduled experiments
-kubectl get schedules -n relibank
+# View active scheduled experiments (substitute the cluster's actual namespace —
+# e.g. relibank-blue / relibank-green on Sandbox, relibank on a single-namespace cluster)
+kubectl get schedules -n <namespace>
 
 # View experiment history
-kubectl get jobs -n relibank
+kubectl get jobs -n <namespace>
 
 # Apply specific experiment manually
 kubectl apply -f chaos_mesh/experiments/relibank-pod-chaos-adhoc.yaml
 kubectl apply -f chaos_mesh/experiments/relibank-stress-scenarios.yaml
 
 # Stop a running experiment
-kubectl delete podchaos <experiment-name> -n relibank
-kubectl delete stresschaos <experiment-name> -n relibank
+kubectl delete podchaos <experiment-name> -n <namespace>
+kubectl delete stresschaos <experiment-name> -n <namespace>
 
 # View experiment details in dashboard or CLI
-kubectl describe schedule relibank-payment-flow-pod-chaos-schedule -n relibank
+kubectl describe schedule relibank-payment-flow-pod-chaos-schedule -n <namespace>
 ```
 
 ## 🔧 Customizing Experiments
@@ -120,7 +121,21 @@ Edit experiment YAML files to customize:
 - **Duration**: Change how long experiments run
 - **Chaos actions**: For pod chaos, choose between pod-kill or pod-failure
 
-All experiments target pods with matching service labels in the `relibank` namespace.
+Each YAML's `namespace` field (and each selector's `namespaces` entry) is hardcoded to `relibank`,
+but the scenario service overrides it at startup with the pod's actual namespace, so experiments
+target the right pods whether the cluster is single-namespace or blue/green
+(`relibank-blue`/`relibank-green`). All experiments target pods with matching service labels in that
+namespace.
+
+Before triggering a new or edited experiment for real, dry-run it via the Scenario Runner API to
+confirm its selector matches at least one live pod:
+
+```bash
+curl -X POST "http://localhost:8000/scenario-runner/api/trigger_chaos/<experiment-name>?dry_run=true"
+```
+
+A `dry_run: true` response with `matched_pods: 0` means the selector doesn't match anything in this
+cluster's namespace — the experiment would silently no-op if triggered for real.
 
 ## 🛡️ Rate Limiting
 

--- a/scenario_service/scenario_service.py
+++ b/scenario_service/scenario_service.py
@@ -143,6 +143,44 @@ CHAOS_RATE_LIMIT = {
     "active_experiments": 0  # Counter for active chaos experiments
 }
 
+
+def get_current_namespace(default: str = "relibank") -> str:
+    """The namespace this pod is actually running in.
+
+    Terraform-managed envs (sandbox/staging/prod) are blue/green
+    (``relibank-blue``/``relibank-green``), while legacy envs (events) are a
+    single ``relibank`` namespace. The chaos-mesh experiment YAMLs hardcode
+    ``relibank``, which silently matches zero pods on a blue/green cluster
+    ("no pods matched selector"). Every pod gets its own namespace mounted by
+    the serviceaccount token by default, so read that instead of trusting the
+    YAML — this keeps chaos scenarios working regardless of which env/color
+    scenario-service itself is deployed into.
+    """
+    try:
+        with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace") as f:
+            return f.read().strip() or default
+    except OSError:
+        return default
+
+
+def _selector_pod_count(selector: dict) -> int:
+    """How many live pods a chaos/stress selector would actually match, without
+    creating any chaos-mesh resource. Backs the trigger endpoints' `dry_run`
+    option — catches selector/namespace drift (e.g. a hardcoded namespace that
+    doesn't exist on this cluster) before it silently no-ops a real experiment.
+    """
+    core_v1 = client.CoreV1Api()
+    label_selectors = selector.get("labelSelectors", {})
+    label_selector_str = ",".join(f"{k}={v}" for k, v in label_selectors.items())
+    total = 0
+    for namespace in selector.get("namespaces", []):
+        try:
+            pods = core_v1.list_namespaced_pod(namespace=namespace, label_selector=label_selector_str)
+            total += len(pods.items)
+        except ApiException as e:
+            print(f"WARNING: dry-run pod lookup failed for namespace '{namespace}': {e}")
+    return total
+
 # Define the lifespan of the application
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -150,6 +188,9 @@ async def lifespan(app: FastAPI):
     Loads chaos experiment definitions on application startup and initializes Kubernetes client.
     """
     global api_client
+
+    current_namespace = get_current_namespace()
+    print(f"INFO: Chaos experiments will target namespace '{current_namespace}' (this pod's own namespace)")
 
     base_dir = Path(__file__).parent.absolute()
     pod_chaos_file = base_dir / "chaos_mesh" / "experiments" / "relibank-pod-chaos-adhoc.yaml"
@@ -173,12 +214,15 @@ async def lifespan(app: FastAPI):
                         name = doc["metadata"]["name"]
                         description = doc["metadata"].get("labels", {}).get("target-flow", "No description available.")
 
-                        # Store the complete experiment spec for ad-hoc execution
+                        # Store the complete experiment spec for ad-hoc execution.
+                        # Override the YAML's hardcoded namespace with wherever this
+                        # pod actually runs (see get_current_namespace) so the
+                        # selector matches real pods on blue/green clusters.
                         CHAOS_EXPERIMENTS[name] = {
-                            "namespace": doc["metadata"]["namespace"],
+                            "namespace": current_namespace,
                             "action": doc["spec"]["action"],
                             "mode": doc["spec"]["mode"],
-                            "selector": doc["spec"]["selector"],
+                            "selector": {**doc["spec"]["selector"], "namespaces": [current_namespace]},
                             "duration": doc["spec"]["duration"],
                             "gracePeriod": doc["spec"]["gracePeriod"],
                             "description": description
@@ -209,11 +253,13 @@ async def lifespan(app: FastAPI):
                         name = doc["metadata"]["name"]
                         description = doc["metadata"].get("labels", {}).get("target-flow", "No description available.")
 
-                        # Store the complete stress experiment spec
+                        # Store the complete stress experiment spec. Override the
+                        # YAML's hardcoded namespace the same way as CHAOS_EXPERIMENTS
+                        # above, so this matches real pods on blue/green clusters.
                         STRESS_EXPERIMENTS[name] = {
-                            "namespace": doc["metadata"]["namespace"],
+                            "namespace": current_namespace,
                             "mode": doc["spec"]["mode"],
-                            "selector": doc["spec"]["selector"],
+                            "selector": {**doc["spec"]["selector"], "namespaces": [current_namespace]},
                             "duration": doc["spec"]["duration"],
                             "stressors": doc["spec"]["stressors"],
                             "description": description
@@ -376,10 +422,29 @@ async def get_scenarios():
     return scenarios_list
 
 @app.post("/scenario-runner/api/trigger_chaos/{scenario_name}")
-async def trigger_chaos_experiment(scenario_name: str):
-    """Triggers a one-time Chaos Mesh experiment with rate limiting."""
+async def trigger_chaos_experiment(scenario_name: str, dry_run: bool = False):
+    """Triggers a one-time Chaos Mesh experiment with rate limiting.
+
+    dry_run=true checks whether the scenario's selector would match any live
+    pods right now — without creating a chaos-mesh resource, consuming the
+    rate limit, or disrupting anything. Meant to be exercised by the test
+    suite on every run so selector/namespace drift is caught immediately
+    instead of silently no-opping the next time someone actually triggers it.
+    """
     if scenario_name not in CHAOS_EXPERIMENTS:
         return {"error": f"Scenario '{scenario_name}' not found."}
+
+    if dry_run:
+        matched = _selector_pod_count(CHAOS_EXPERIMENTS[scenario_name]["selector"])
+        return {
+            "status": "success" if matched > 0 else "warning",
+            "dry_run": True,
+            "message": (
+                f"Dry run: selector would match {matched} pod(s)." if matched > 0
+                else "Dry run: selector matched 0 pods — triggering this for real would silently no-op."
+            ),
+            "matched_pods": matched
+        }
 
     # Check rate limit cooldown period
     now = datetime.now()
@@ -587,10 +652,28 @@ async def trigger_dem_memory_leak_10min():
     }
 
 @app.post("/scenario-runner/api/trigger_stress/{scenario_name}")
-async def trigger_stress_experiment(scenario_name: str):
-    """Triggers a one-time Stress Chaos experiment with rate limiting."""
+async def trigger_stress_experiment(scenario_name: str, dry_run: bool = False):
+    """Triggers a one-time Stress Chaos experiment with rate limiting.
+
+    dry_run=true checks whether the scenario's selector would match any live
+    pods right now — without creating a chaos-mesh resource, consuming the
+    rate limit, or disrupting anything. See trigger_chaos_experiment's
+    docstring for why this exists.
+    """
     if scenario_name not in STRESS_EXPERIMENTS:
         return {"error": f"Stress scenario '{scenario_name}' not found."}
+
+    if dry_run:
+        matched = _selector_pod_count(STRESS_EXPERIMENTS[scenario_name]["selector"])
+        return {
+            "status": "success" if matched > 0 else "warning",
+            "dry_run": True,
+            "message": (
+                f"Dry run: selector would match {matched} pod(s)." if matched > 0
+                else "Dry run: selector matched 0 pods — triggering this for real would silently no-op."
+            ),
+            "matched_pods": matched
+        }
 
     # Check rate limit cooldown period
     now = datetime.now()

--- a/tests/nrql_color.py
+++ b/tests/nrql_color.py
@@ -13,26 +13,31 @@ It renders to ``AND `namespaceName` = 'relibank-blue'`` when a color is directed
 string when ``TARGET_COLOR`` is unset (e.g. the scheduled cron resolving to the active color
 with no directive) — so the query stays env-level.
 
-Not all telemetry carries the namespace: the mssql-collector ``Metric`` stream and browser
-events (``PageView``/``BrowserInteraction``, shared browser app) have no namespace dimension,
-so they remain color-blind by necessity — do not use this helper for them.
+Not all telemetry carries the namespace: the mssql-collector ``Metric`` stream, browser
+events (``PageView``/``BrowserInteraction``, shared browser app), and ``Log`` have no
+namespace dimension, so they remain color-blind by necessity — do not use this helper for
+them (``color_filter('Log')`` etc. is a safe, permanent no-op below, not just "not yet wired
+up").
 """
 import os
 
 # (attribute, value-template) carrying the color, per NR event type. The value template is
-# formatted with the effective color. Two flavors:
+# formatted with the effective color.
 #   - APM Transaction/TransactionError: the ``deploy.color`` custom attribute (value = the bare
 #     color, e.g. "blue"), stamped by utils/process_headers.py. nri-metadata-injection does NOT
 #     put a namespace on APM events, so this custom attribute is how APM is color-scoped.
-#   - Span/Log: the k8s namespace nri-metadata-injection stamps (value = "relibank-<color>"):
-#     Span -> k8s.namespace.name, Log -> namespace_name.
-# Metric (mssql collector) and browser PageView have no color dimension and are intentionally
-# absent -> color_filter() is a no-op for them (they stay env-level).
+#   - Span: the k8s namespace nri-metadata-injection stamps (value = "relibank-<color>") ->
+#     k8s.namespace.name.
+# Log is deliberately absent: relibank services ship logs via the APM agent's own log
+# forwarding (newrelic.source = "logs.APM"), not the nri-metadata-injection/Fluent Bit
+# pipeline, so `namespace_name` is never stamped on Log records — a namespace filter there
+# would silently zero every result. Metric (mssql collector) and browser PageView also have no
+# color dimension. All three are intentionally absent -> color_filter() is a no-op for them
+# (they stay env-level).
 _COLOR_DIM = {
     "Transaction": ("deploy.color", "{color}"),
     "TransactionError": ("deploy.color", "{color}"),
     "Span": ("k8s.namespace.name", "relibank-{color}"),
-    "Log": ("namespace_name", "relibank-{color}"),
 }
 
 

--- a/tests/test_db_pool_e2e.py
+++ b/tests/test_db_pool_e2e.py
@@ -143,6 +143,7 @@ def test_db_pool_e2e_with_new_relic_validation(reset_scenario):
 
     # Step 3: Generate traffic to both pools
     print("\n📝 Step 3: Generating traffic to both database pools...")
+    traffic_start_ms = int(time.time() * 1000)
     traffic_count = 20
 
     for i in range(traffic_count):
@@ -179,14 +180,18 @@ def test_db_pool_e2e_with_new_relic_validation(reset_scenario):
     # Step 5: Validate custom attributes in New Relic
     print("\n📝 Step 5: Validating custom attributes in New Relic...")
 
-    # Query for db.pool_id (custom attributes don't get custom. prefix when using add_custom_attribute)
+    # Query for db.pool_id (custom attributes don't get custom. prefix when using add_custom_attribute).
+    # Scoped to this test's own requests (Alice/Bob) — pool_id is a hash of user_id, so any
+    # concurrent traffic (e.g. the scenario service's own load generator) lands in the same
+    # pool-a/pool-b buckets and would otherwise dilute the Step 6 performance comparison.
     nrql = f"""
     SELECT count(*), uniques(db.pool_id)
     FROM Transaction
     WHERE appName LIKE '%Accounts Service%'
       AND db.pool_id IS NOT NULL
+      AND (request.uri LIKE '%alice.j@relibank.com%' OR request.uri LIKE '%bob.w@relibank.com%')
       {color_filter('Transaction')}
-    SINCE 10 minutes ago
+    SINCE {traffic_start_ms}
     """
 
     results = query_nerdgraph(nrql)
@@ -214,9 +219,10 @@ def test_db_pool_e2e_with_new_relic_validation(reset_scenario):
     FROM Transaction
     WHERE appName LIKE '%Accounts Service%'
       AND db.pool_id IS NOT NULL
+      AND (request.uri LIKE '%alice.j@relibank.com%' OR request.uri LIKE '%bob.w@relibank.com%')
       {color_filter('Transaction')}
     FACET db.pool_id
-    SINCE 10 minutes ago
+    SINCE {traffic_start_ms}
     """
 
     perf_results = query_nerdgraph(perf_nrql)

--- a/tests/test_dem_scenarios.py
+++ b/tests/test_dem_scenarios.py
@@ -7,8 +7,8 @@ import os
 SCENARIO_SERVICE_URL = os.getenv("SCENARIO_SERVICE_URL", "http://localhost:8000")
 NR_API_KEY = os.getenv("NEW_RELIC_USER_API_KEY")
 NR_ACCOUNT_ID = os.getenv("NEW_RELIC_ACCOUNT_ID")
-NR_APP_NAME = os.getenv("NR_APP_NAME", "ReliBank (Analysts) - Accounts Service")
-NR_BROWSER_APP_NAME = os.getenv("NR_BROWSER_APP_NAME", "ReliBank - Customer Portal")
+NR_APP_NAME = os.getenv("NR_APP_NAME") or f"{os.getenv('APP_NAME', 'ReliBank')} - Accounts Service"
+NR_BROWSER_APP_NAME = os.getenv("NR_BROWSER_APP_NAME", "Relibank - Customer Portal")
 SSL_VERIFY = os.getenv("SSL_VERIFY", "true").lower() == "true"
 
 

--- a/tests/test_newrelic_risk_assessment.py
+++ b/tests/test_newrelic_risk_assessment.py
@@ -108,6 +108,23 @@ def query_nerdgraph(nrql_query: str) -> List[Dict]:
     return data.get("data", {}).get("actor", {}).get("account", {}).get("nrql", {}).get("results", [])
 
 
+def query_nerdgraph_until(nrql_query: str, count_key: str, max_wait: int = 30, interval: int = 5) -> List[Dict]:
+    """Poll a NRQL count query until count_key is > 0 or max_wait elapses.
+
+    Log/span ingestion lag is usually well under max_wait but occasionally isn't,
+    so polling avoids both flaky early failures and always paying the full wait.
+    """
+    elapsed = 0
+    while True:
+        results = query_nerdgraph(nrql_query)
+        if results and results[0].get(count_key, 0) > 0:
+            return results
+        if elapsed >= max_wait:
+            return results
+        time.sleep(interval)
+        elapsed += interval
+
+
 def get_db_connection():
     """Get database connection"""
     return pyodbc.connect(CONNECTION_STRING)
@@ -234,12 +251,8 @@ def test_risk_assessment_logs_in_newrelic(reset_risk_scenarios):
         print(f"   Payment {i+1}: status={result['status_code']}")
         time.sleep(1)
 
-    # Wait for logs to appear in New Relic
-    print("\n2. Waiting 30 seconds for logs to appear in New Relic...")
-    time.sleep(30)
-
     # Query for risk assessment logs
-    print("\n3. Querying New Relic Logs...")
+    print("\n2. Querying New Relic Logs (polling up to 30s for ingestion)...")
 
     # Query for logs containing risk assessment keywords
     nrql = f"""
@@ -253,12 +266,12 @@ def test_risk_assessment_logs_in_newrelic(reset_risk_scenarios):
     SINCE 2 minutes ago
     """
 
-    results = query_nerdgraph(nrql)
+    results = query_nerdgraph_until(nrql, "log_count")
 
-    print(f"\n4. Results:")
+    print(f"\n3. Results:")
     if results:
         log_count = results[0].get('log_count', 0)
-        sample_message = results[0].get('sample_message', 'N/A')
+        sample_message = results[0].get('sample_message') or 'N/A'
         print(f"   Log entries found: {log_count}")
         print(f"   Sample message: {sample_message[:100]}...")
 
@@ -318,26 +331,22 @@ def test_declined_payment_shows_in_newrelic(reset_risk_scenarios):
     print("\n3. Disabling rogue agent...")
     disable_rogue_agent()
 
-    # Wait for logs and Kafka processing
-    print("\n4. Waiting 30 seconds for logs and database entries...")
-    time.sleep(30)
-
     # Query for declined payment logs
-    print("\n5. Querying New Relic for declined payment logs...")
+    print("\n4. Querying New Relic for declined payment logs (polling up to 30s for ingestion)...")
 
     nrql = f"""
     SELECT count(*) as declined_log_count
     FROM Log
-    WHERE (message LIKE '%declined%' OR message LIKE '%DECLINED%'
+    WHERE ((message LIKE '%declined%' OR message LIKE '%DECLINED%')
       AND entity.name IN ('{APP_NAME_PREFIX} - Bill Pay Service',
                           '{APP_NAME_PREFIX} - Support Service'))
       {color_filter('Log')}
     SINCE 3 minutes ago
     """
 
-    results = query_nerdgraph(nrql)
+    results = query_nerdgraph_until(nrql, "declined_log_count")
 
-    print(f"\n6. Results:")
+    print(f"\n5. Results:")
     if results:
         declined_log_count = results[0].get('declined_log_count', 0)
         print(f"   Declined payment log entries: {declined_log_count}")
@@ -358,7 +367,7 @@ def test_declined_payment_shows_in_newrelic(reset_risk_scenarios):
         pytest.skip("No declined payment logs found in New Relic")
 
     # Validate database entries for declined payments
-    print(f"\n7. Validating database entries for declined payments...")
+    print(f"\n6. Validating database entries for declined payments...")
     if declined_bill_ids:
         db_entries_found = 0
         db_entries_missing = 0
@@ -372,9 +381,12 @@ def test_declined_payment_shows_in_newrelic(reset_risk_scenarios):
                 print(f"     - Status: {transaction['Status']}")
                 print(f"     - DeclineReason: {transaction['DeclineReason'][:80]}...")
 
-                # Validate transaction data
-                assert transaction['EventType'] == 'BillPaymentDeclined', \
-                    f"Expected EventType='BillPaymentDeclined', got '{transaction['EventType']}'"
+                # Validate transaction data. transaction_service writes one row per side of the
+                # transfer (BillPaymentDeclinedFromAcct for the debit, ...ToAcct for the
+                # credit — see transaction_service.py:439-469); fetchone() returns whichever
+                # side sorts first, so accept either.
+                assert transaction['EventType'] in ('BillPaymentDeclinedFromAcct', 'BillPaymentDeclinedToAcct'), \
+                    f"Expected EventType in ('BillPaymentDeclinedFromAcct', 'BillPaymentDeclinedToAcct'), got '{transaction['EventType']}'"
                 assert transaction['Status'] == 'declined', \
                     f"Expected Status='declined', got '{transaction['Status']}'"
                 assert transaction['DeclineReason'] is not None, \
@@ -440,12 +452,8 @@ def test_agent_model_tracking_in_newrelic(reset_risk_scenarios):
     # Cleanup
     disable_rogue_agent()
 
-    # Wait for logs
-    print("\n3. Waiting 30 seconds for logs to appear in New Relic...")
-    time.sleep(30)
-
     # Query for agent model in logs
-    print("\n4. Querying New Relic for agent model tracking...")
+    print("\n3. Querying New Relic for agent model tracking (polling up to 30s for ingestion)...")
 
     nrql = f"""
     SELECT count(*) as log_count
@@ -456,9 +464,9 @@ def test_agent_model_tracking_in_newrelic(reset_risk_scenarios):
     SINCE 3 minutes ago
     """
 
-    results = query_nerdgraph(nrql)
+    results = query_nerdgraph_until(nrql, "log_count")
 
-    print(f"\n5. Results:")
+    print(f"\n4. Results:")
     if results:
         log_count = results[0].get('log_count', 0)
         print(f"   Agent model log entries: {log_count}")
@@ -497,12 +505,8 @@ def test_risk_assessment_ebpf_traces(reset_risk_scenarios):
         print(f"   Payment {i+1}: status={result['status_code']}")
         time.sleep(1)
 
-    # Wait for traces
-    print("\n2. Waiting 30 seconds for traces to appear in New Relic...")
-    time.sleep(30)
-
     # Query for eBPF spans from Risk Assessment Service
-    print("\n3. Querying for eBPF spans from Risk Assessment Service...")
+    print("\n2. Querying for eBPF spans from Risk Assessment Service (polling up to 30s for ingestion)...")
 
     nrql = f"""
     SELECT count(*) as span_count, average(duration) as avg_duration_ms
@@ -514,17 +518,17 @@ def test_risk_assessment_ebpf_traces(reset_risk_scenarios):
     SINCE 3 minutes ago
     """
 
-    results = query_nerdgraph(nrql)
+    results = query_nerdgraph_until(nrql, "span_count")
 
-    print(f"\n4. Results:")
+    print(f"\n3. Results:")
     if results and results[0].get('span_count', 0) > 0:
         span_count = results[0].get('span_count', 0)
-        avg_duration = results[0].get('avg_duration_ms', 0)
+        avg_duration = results[0].get('avg_duration_ms') or 0
         print(f"   eBPF spans found: {span_count}")
         print(f"   Average duration: {avg_duration:.2f}ms")
 
         # Query for span attributes
-        print("\n5. Checking for risk assessment attributes on spans...")
+        print("\n4. Checking for risk assessment attributes on spans...")
         nrql_attrs = f"""
         SELECT count(*) as spans_with_attrs
         FROM Span

--- a/tests/test_nrdot_mssql_collector.py
+++ b/tests/test_nrdot_mssql_collector.py
@@ -43,10 +43,15 @@ NEW_RELIC_ACCOUNT_ID = os.getenv("NEW_RELIC_ACCOUNT_ID", "")
 TRANSACTION_SERVICE_URL  = os.getenv("TRANSACTION_SERVICE_URL", "http://localhost:5001")
 NERDGRAPH_URL        = "https://api.newrelic.com/graphql"
 
-pytestmark = pytest.mark.skipif(
-    not NEW_RELIC_API_KEY,
-    reason="NEW_RELIC_USER_API_KEY environment variable not set",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        not NEW_RELIC_API_KEY,
+        reason="NEW_RELIC_USER_API_KEY environment variable not set",
+    ),
+    # generate_mssql_load's 3 phases sleep 30s+300s+120s = 450s before any assertion runs;
+    # override the workflow's blanket --timeout=300 so pytest-timeout doesn't kill mid-fixture.
+    pytest.mark.timeout(600),
+]
 
 
 def query_nerdgraph(nrql: str) -> list:

--- a/tests/test_scenario_service.py
+++ b/tests/test_scenario_service.py
@@ -347,11 +347,14 @@ def test_scenario_persistence():
     # Retrieve and verify settings persisted
     scenarios = requests.get(f"{SCENARIO_SERVICE_URL}/scenario-runner/api/payment-scenarios").json()["scenarios"]
 
-    assert scenarios["gateway_timeout_enabled"] is True, "Settings did not persist"
-    assert scenarios["gateway_timeout_probability"] == 33.3, "Probability did not persist"
-    assert scenarios["gateway_timeout_delay"] == 4.5, "Delay did not persist"
+    try:
+        assert scenarios["gateway_timeout_enabled"] is True, "Settings did not persist"
+        assert scenarios["gateway_timeout_probability"] == 33.3, "Probability did not persist"
+        assert scenarios["gateway_timeout_delay"] == 4.5, "Delay did not persist"
 
-    print("✓ Scenario settings persist correctly")
+        print("✓ Scenario settings persist correctly")
+    finally:
+        requests.post(f"{SCENARIO_SERVICE_URL}/scenario-runner/api/payment-scenarios/reset")
 
 
 # ===== CHAOS SCENARIOS SMOKE TESTS =====
@@ -474,6 +477,58 @@ def test_locust_start_stop():
             print(f"⚠ Unexpected status: {start_response.status_code}")
     except Exception as e:
         print(f"⚠ Locust scenarios test skipped: {e}")
+
+
+# These "stress-chaos"-labeled scenario names have their own dedicated FastAPI route
+# (@app.post("/scenario-runner/api/trigger_stress/dem-memory-leak-45min") etc.), registered
+# as an exact-match path *before* the generic dry_run-aware
+# /trigger_stress/{scenario_name} handler. FastAPI always matches the literal path first,
+# so `?dry_run=true` against these silently reaches the dedicated handler instead — which
+# ignores the param and unconditionally flips a real in-process feature flag (no chaos-mesh
+# selector involved at all, so "matched_pods" doesn't even apply). Never call these from a
+# "dry run" test — do NOT remove this exclusion without adding real dry_run support to
+# those two dedicated endpoints first.
+_SCENARIOS_WITHOUT_DRY_RUN_SUPPORT = {"dem-memory-leak-45min", "dem-memory-leak-10min"}
+
+
+def test_all_chaos_scenarios_have_matching_pods():
+    """Dry-run every registered chaos/stress scenario and assert its selector
+    actually matches at least one live pod. Catches selector/namespace drift
+    (e.g. a hardcoded namespace that doesn't exist on this cluster's blue/green
+    setup) before it silently no-ops the next time someone triggers it for real.
+    """
+    scenarios = requests.get(f"{SCENARIO_SERVICE_URL}/scenario-runner/api/scenarios", timeout=10).json()
+    checked = []
+    for s in scenarios:
+        if s["type"] not in ("chaos-mesh", "stress-chaos"):
+            continue  # payment/ab_test/feature_flag scenarios aren't selector-based
+        if s["name"] in _SCENARIOS_WITHOUT_DRY_RUN_SUPPORT:
+            continue
+        endpoint = "trigger_chaos" if s["type"] == "chaos-mesh" else "trigger_stress"
+        resp = requests.post(
+            f"{SCENARIO_SERVICE_URL}/scenario-runner/api/{endpoint}/{s['name']}",
+            params={"dry_run": "true"},
+            timeout=10,
+        )
+        assert resp.status_code == 200, f"{s['name']}: dry-run call failed ({resp.status_code})"
+        data = resp.json()
+        # Confirm the call actually reached the dry_run-aware code path rather than some
+        # other route that ignored the param and triggered for real — if a future scenario
+        # ever adds a dedicated route like the two excluded above, we want a loud failure
+        # here, not a silently-skipped assertion.
+        assert data.get("dry_run") is True, (
+            f"Scenario '{s['name']}' ({s['type']}) did not return dry_run=true — this call "
+            f"may not have been a dry run at all and could have triggered a real action. "
+            f"Response: {data}. If this scenario has its own dedicated, non-dry-run-aware "
+            f"route, add it to _SCENARIOS_WITHOUT_DRY_RUN_SUPPORT above instead of letting "
+            f"this test call it."
+        )
+        checked.append((s["name"], data.get("matched_pods", 0)))
+        assert data.get("matched_pods", 0) > 0, (
+            f"Scenario '{s['name']}' ({s['type']}) matched 0 pods — it would silently "
+            f"no-op if triggered for real. {data.get('message')}"
+        )
+    print(f"✓ {len(checked)} chaos/stress scenarios all matched >=1 pod: {checked}")
 
 
 if __name__ == "__main__":

--- a/transaction_service/transaction_service.py
+++ b/transaction_service/transaction_service.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+import re
 import sys
 import json
 import logging
@@ -23,6 +24,24 @@ from utils import process_headers
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 
 newrelic.agent.initialize()
+
+
+def _error_group_callback(exception, info):
+    """Collapse errors that only differ by a runtime value (e.g. an account ID in a
+    URL, like '.../account/type/921' vs '.../account/type/872') into one error
+    group instead of fragmenting the Errors Inbox into hundreds of near-identical
+    groups. Only sets error.group.name — error.message is untouched, so anything
+    asserting on message content elsewhere is unaffected.
+    """
+    message = info.get("error.message") or ""
+    if not message:
+        return None
+    normalized = re.sub(r"\d+", "N", message)
+    return f"{info.get('error.class', 'Unknown')}: {normalized}"
+
+
+newrelic.agent.set_error_group_callback(_error_group_callback)
+
 
 def get_propagation_headers(request: Request) -> dict:
     """
@@ -247,7 +266,7 @@ async def get_account_type(account_id: int, headers: dict = None):
     Makes an API call to the accounts service to get the account type.
     Optionally propagates headers if provided.
     """
-    accounts_service_url = os.getenv("ACCOUNTS_SERVICE_URL", "http://accounts-service:5000")
+    accounts_service_url = os.getenv("ACCOUNTS_SERVICE_URL", "http://accounts-service:5002")
     async with httpx.AsyncClient() as client:
         try:
             response = await client.get(


### PR DESCRIPTION
🚀 Pull Request
========================

🎯 PR Type
----------
-   [x] **Feature:** Adds new functionality or user-facing change.
-   [x] **Bug Fix:** Solves a defect or incorrect behavior.
-   [ ] **Refactor:** Improves code structure/readability without changing external behavior.
-   [ ] **Documentation:** Updates to README, Wiki, or internal docs.
-   [ ] **Chore:** Non-code changes (e.g., CI configuration, dependency bumps).

1\. Issue Tracking & Reference
------------------------------
-   **Ticket Number(s):** N/A
-   **Ticket Link(s):** N/A

2\. Summary of Changes
----------------------
Fixes a chain of real bugs found while investigating a transaction-service error spike, and hardens the sandbox test suite so these classes of bug are caught by CI going forward.
-   **Expected Outcome:** Transaction/accounts/bill-pay services no longer produce spurious errors from the fixed bugs; chaos/stress scenarios actually execute against the correct pods on blue/green instead of silently no-op'ing; the sandbox test suite runs green and is more resistant to flakiness/regressions.

### Detailed Change Log & Justification
-   **Change 1:** Initialize `risk_decline_info` in `bill_pay_service.py`'s card-payment flow.
    -   **Justification:** stolen_card + saveCard:true caused `stripe.PaymentMethod.attach()` to raise before the risk-assessment block ran, and the shared CardError handler read `risk_decline_info` assuming it was always set — this crashed with an `UnboundLocalError`.
-   **Change 2:** Stop rewriting legitimate 404s into 500s in `accounts_service.py` (`get_user`, `get_accounts`, `get_account_type`, `create_account`).
    -   **Justification:** These endpoints caught `HTTPException` in a generic `except Exception`, turning "not found" responses into 500s and cluttering the Errors Inbox with ~104 spurious error groups.
-   **Change 3:** Fix `ACCOUNTS_SERVICE_URL` default port in `transaction_service.py` and wire it via the ConfigMap in `transaction-service-deployment.yaml`; add a New Relic error-group callback to normalize dynamic values in error messages.
    -   **Justification:** The default port (5000) didn't match accounts-service's actual port (5002), and the var wasn't wired on the Events deployment, causing real request failures; the error-group callback prevents one class of dynamic-value error from fragmenting into many separate error groups.
-   **Change 4:** Detect the pod's real Kubernetes namespace at runtime in `scenario_service.py` and override each chaos-mesh/stress-chaos experiment's hardcoded `namespace: relibank`.
    -   **Justification:** Every experiment YAML hardcoded a legacy pre-blue/green namespace. On Sandbox (`relibank-blue`/`relibank-green`) this made selectors silently match zero pods, so triggering a scenario appeared to succeed but did nothing.
-   **Change 5:** Add a `dry_run` mode to `trigger_chaos`/`trigger_stress` plus a new test, `test_all_chaos_scenarios_have_matching_pods`, that dry-runs every registered scenario and asserts its selector matches at least one live pod.
    -   **Justification:** Prevents Change 4's class of bug (a selector silently matching zero pods) from regressing unnoticed again; the dry run is read-only and safe to run on every CI push.
-   **Change 6:** Sandbox test-suite reliability fixes across `tests/` — fixed an NRQL operator-precedence bug, replaced blind `time.sleep(30)` calls with a polling helper, fixed a stale `EventType` assertion, made `color_filter('Log')` a permanent no-op, scoped db-pool NRQL to avoid cross-traffic dilution, raised `test_nrdot_mssql_collector`'s timeout to 600s, derived NR app names from env vars instead of hardcoded defaults, reset scenario state after `test_scenario_persistence`, and wired `APP_NAME`/`NR_BROWSER_APP_NAME` into CI.
    -   **Justification:** These were each independently causing flaky or incorrect test results on Sandbox, unrelated to the actual application bugs, making it hard to trust CI signal while investigating the above.
-   **Change 7:** Updated `docs/SCENARIO_AUTHORING.md`, `scenario_service/chaos_mesh/README.md`, and `scenario_service/CLAUDE.md` to document the namespace-override behavior from Change 4 and the new `dry_run` param from Change 5.
    -   **Justification:** These docs still told authors to hardcode `namespace: relibank` and described experiments as targeting a single `relibank` namespace, with no mention of the runtime override or the new dry-run validation path — leaving them would make the docs actively misleading on blue/green clusters.

3\. Testing
-----------
Ran the full sandbox GitHub Actions test suite repeatedly against Sandbox (`deploy-relibank.yml` post-deployment tests and `test-suite.yml`), iterating until green after each fix.

### Testing Strategy
-   **Environment Used:** Sandbox
-   **Production Safety Assessment:** Bug fixes are scoped to error-path/config code already exercised by existing services; the new `dry_run` mode is read-only (creates no chaos-mesh resources, never touches rate-limit state), so it's safe to run in CI on every push. All fixes were verified end-to-end on Sandbox before merge, including confirming pods were actually running the new code (image digest + live source check), not just redeployed.
-   **What areas were NOT tested and why?** Did not verify every fix against Staging/Events directly — the `ACCOUNTS_SERVICE_URL` fix was specific to Events' ConfigMap wiring and was checked there, but the rest were validated on Sandbox only, which is where they were discovered.

### Coverage Details

| Scenario      | Details                                                                    | Results                           |
| ------------- | -------------------------------------------------------------------------- | --------------------------------- |
| Happy Path    | Full sandbox test suite via `deploy-relibank.yml` post-deployment tests    | Green — python-tests, frontend-tests, test-summary all passing |
| Edge Case 1   | Triggered real 404s (missing user/account) against accounts-service post-fix | Correctly returned 404, no longer 500 |
| Edge Case 2   | Dry-ran every registered chaos/stress scenario against the pre-fix selector shape (`namespaces: ["relibank"]`) | Correctly returned `"status": "warning"`, `matched_pods: 0`, matching the originally observed no-op behavior |

4\. Evidence
------------
-   **Console/Log Output Snippets:** Verified via New Relic NRQL queries (error group counts before/after the accounts-service fix, chaos-mesh event confirmation) and `kubectl` pod image-digest/source inspection.
-   **Test Report Links:** GitHub Actions runs on `fix/transaction-service-and-tests` against Sandbox (`deploy-relibank.yml`, `test-suite.yml`) — final runs green across python-tests/frontend-tests/test-summary.

5\. Review and Merge Checklist
------------------------------
-   [x] All blocking review comments from the latest round are **resolved**.
-   [x] This branch has been rebased against the `main` branch and all **merge conflicts are resolved**.
-   [x] The code includes sufficient comments, particularly in complex or non-obvious areas.
-   [x] The code adheres to project **coding standards** (linting, style guides, best practices).
-   [x] Relevant documentation and runbooks have been updated, if necessary.
-   [x] My changes generate no new warnings or errors.
-   [x] My commits are squashed into a single, descriptive commit.
-   [x] My test results are uploaded as a text file, and new tests were created where required. Successful CI runs instead: [Relibank Test Suite](https://github.com/newrelic/relibank/actions/runs/31628958547), [Deploy ReliBank (post-deployment tests)](https://github.com/newrelic/relibank/actions/runs/31612438068).
